### PR TITLE
Fixing devcontainer build error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,10 @@
     "ghcr.io/azure/azure-dev/azd:latest": {},
     "ghcr.io/devcontainers/features/dotnet:latest": {},
     "ghcr.io/devcontainers/features/github-cli:latest": {},
-    "ghcr.io/devcontainers/features/java:latest": {
+    "ghcr.io/devcontainers/features/java:1": {
       "installGradle": true,
-      "installMaven": true
+      "installMaven": true,
+      "version": "21"
     },
     "ghcr.io/devcontainers/features/docker-in-docker": {},
     "ghcr.io/devcontainers/features/node:latest": {},
@@ -49,4 +50,3 @@
     }
   }
 }
-


### PR DESCRIPTION
It wouldn't build the devcontainer in my machine as it didn't like the lack of version of Java.
