### PR TITLE
Adding `ResourceName` attribute to our extension methods

### DIFF
--- a/src/Aspire.CommunityToolkit.Hosting.Azure.DataApiBuilder/DataApiBuilderHostingExtension.cs
+++ b/src/Aspire.CommunityToolkit.Hosting.Azure.DataApiBuilder/DataApiBuilderHostingExtension.cs
@@ -17,7 +17,7 @@ public static class DataApiBuilderHostingExtension
     /// <param name="port">The port number for the Data API Builder container.</param>"
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<DataApiBuilderContainerResource> AddDataAPIBuilder(this IDistributedApplicationBuilder builder,
-        string name,
+        [ResourceName] string name,
         string configFilePath = "./dab-config.json",
         int? port = null)
     {

--- a/src/Aspire.CommunityToolkit.Hosting.Azure.StaticWebApps/SwaAppHostingExtension.cs
+++ b/src/Aspire.CommunityToolkit.Hosting.Azure.StaticWebApps/SwaAppHostingExtension.cs
@@ -11,7 +11,7 @@ public static class SwaAppHostingExtension
     /// <param name="name">The name of the resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>This resource will not be included in the published manifest.</remarks>
-    public static IResourceBuilder<SwaResource> AddSwaEmulator(this IDistributedApplicationBuilder builder, string name) =>
+    public static IResourceBuilder<SwaResource> AddSwaEmulator(this IDistributedApplicationBuilder builder, [ResourceName] string name) =>
         builder.AddSwaEmulator(name, new SwaResourceOptions());
 
     /// <summary>
@@ -22,7 +22,7 @@ public static class SwaAppHostingExtension
     /// <param name="options">The <see cref="SwaResourceOptions"/> to configure the SWA CLI.</param>"
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>This resource will not be included in the published manifest.</remarks>
-    public static IResourceBuilder<SwaResource> AddSwaEmulator(this IDistributedApplicationBuilder builder, string name, SwaResourceOptions options)
+    public static IResourceBuilder<SwaResource> AddSwaEmulator(this IDistributedApplicationBuilder builder, [ResourceName] string name, SwaResourceOptions options)
     {
         var resource = new SwaResource(name, Environment.CurrentDirectory);
         return builder.AddResource(resource)

--- a/src/Aspire.CommunityToolkit.Hosting.Golang/GolangAppHostingExtension.cs
+++ b/src/Aspire.CommunityToolkit.Hosting.Golang/GolangAppHostingExtension.cs
@@ -17,7 +17,7 @@ public static class GolangAppHostingExtension
     /// <param name="port">This is the port that will be given to other resource to communicate with this resource.</param>"
     /// <param name="args">The optinal arguments to be passed to the executable when it is started.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<GolangAppExecutableResource> AddGolangApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, int port = 8080, string[]? args = null) 
+    public static IResourceBuilder<GolangAppExecutableResource> AddGolangApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string workingDirectory, int port = 8080, string[]? args = null) 
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
         ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(name));

--- a/src/Aspire.CommunityToolkit.Hosting.Java/JavaAppHostingExtension.cs
+++ b/src/Aspire.CommunityToolkit.Hosting.Java/JavaAppHostingExtension.cs
@@ -17,7 +17,7 @@ public static class JavaAppHostingExtension
     /// <param name="name">The name of the resource.</param>
     /// <param name="options">The <see cref="JavaAppContainerResourceOptions"/> to configure the Java application.</param>"
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<JavaAppContainerResource> AddJavaApp(this IDistributedApplicationBuilder builder, string name, JavaAppContainerResourceOptions options)
+    public static IResourceBuilder<JavaAppContainerResource> AddJavaApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, JavaAppContainerResourceOptions options)
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
         ArgumentNullException.ThrowIfNull(options, nameof(options));
@@ -46,7 +46,7 @@ public static class JavaAppHostingExtension
     /// <param name="name">The name of the resource.</param>
     /// <param name="options">The <see cref="JavaAppContainerResourceOptions"/> to configure the Java application.</param>"
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<JavaAppContainerResource> AddSpringApp(this IDistributedApplicationBuilder builder, string name, JavaAppContainerResourceOptions options) =>
+    public static IResourceBuilder<JavaAppContainerResource> AddSpringApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, JavaAppContainerResourceOptions options) =>
         builder.AddJavaApp(name, options);
 
     /// <summary>
@@ -57,7 +57,7 @@ public static class JavaAppHostingExtension
     /// <param name="workingDirectory">The working directory to use for the command. If null, the working directory of the current process is used.</param>
     /// <param name="options">The <see cref="JavaAppExecutableResourceOptions"/> to configure the Java application.</param>"
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<JavaAppExecutableResource> AddJavaApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, JavaAppExecutableResourceOptions options)
+    public static IResourceBuilder<JavaAppExecutableResource> AddJavaApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string workingDirectory, JavaAppExecutableResourceOptions options)
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
         ArgumentNullException.ThrowIfNull(options, nameof(options));
@@ -87,7 +87,7 @@ public static class JavaAppHostingExtension
     /// <param name="workingDirectory">The working directory to use for the command. If null, the working directory of the current process is used.</param>
     /// <param name="options">The <see cref="JavaAppExecutableResourceOptions"/> to configure the Java application.</param>"
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<JavaAppExecutableResource> AddSpringApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, JavaAppExecutableResourceOptions options) =>
+    public static IResourceBuilder<JavaAppExecutableResource> AddSpringApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string workingDirectory, JavaAppExecutableResourceOptions options) =>
         builder.AddJavaApp(name, workingDirectory, options);
 
     private static IResourceBuilder<JavaAppContainerResource> WithJavaDefaults(

--- a/src/Aspire.CommunityToolkit.Hosting.NodeJS.Extensions/NodeJSHostingExtensions.cs
+++ b/src/Aspire.CommunityToolkit.Hosting.NodeJS.Extensions/NodeJSHostingExtensions.cs
@@ -17,7 +17,7 @@ public static class NodeJSHostingExtensions
     /// <param name="packageManager">The package manager to use. Default is npm.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>This uses the specified package manager (default npm) method internally but sets defaults that would be expected to run a Vite app, such as the command to run the dev server and exposing the HTTP endpoints.</remarks>
-    public static IResourceBuilder<NodeAppResource> AddViteApp(this IDistributedApplicationBuilder builder, string name, string? workingDirectory = null, string packageManager = "npm")
+    public static IResourceBuilder<NodeAppResource> AddViteApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string? workingDirectory = null, string packageManager = "npm")
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -45,7 +45,7 @@ public static class NodeJSHostingExtensions
     /// <param name="scriptName">The npm script to execute. Defaults to "start".</param>
     /// <param name="args">The arguments to pass to the command.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<NodeAppResource> AddYarnApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, string scriptName = "start", string[]? args = null)
+    public static IResourceBuilder<NodeAppResource> AddYarnApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string workingDirectory, string scriptName = "start", string[]? args = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -73,7 +73,7 @@ public static class NodeJSHostingExtensions
     /// <param name="scriptName">The npm script to execute. Defaults to "start".</param>
     /// <param name="args">The arguments to pass to the command.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<NodeAppResource> AddPnpmApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, string scriptName = "start", string[]? args = null)
+    public static IResourceBuilder<NodeAppResource> AddPnpmApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string workingDirectory, string scriptName = "start", string[]? args = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);

--- a/src/Aspire.CommunityToolkit.Hosting.Ollama/OllamaResourceBuilderExtensions.cs
+++ b/src/Aspire.CommunityToolkit.Hosting.Ollama/OllamaResourceBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class OllamaResourceBuilderExtensions
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="port">An optional fixed port to bind to the Ollama container. This will be provided randomly by Aspire if not set.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<OllamaResource> AddOllama(this IDistributedApplicationBuilder builder, string name, int? port = null)
+    public static IResourceBuilder<OllamaResource> AddOllama(this IDistributedApplicationBuilder builder, [ResourceName] string name, int? port = null)
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
         ArgumentNullException.ThrowIfNull(name, nameof(name));
@@ -45,7 +45,7 @@ public static class OllamaResourceBuilderExtensions
     [Obsolete("Use AddOllama without a model name, and then the AddModel extension method to add models.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "<Pending>")]
     public static IResourceBuilder<OllamaResource> AddOllama(this IDistributedApplicationBuilder builder,
-      string name = "Ollama", int? port = null, string modelName = "llama3")
+      [ResourceName] string name = "Ollama", int? port = null, string modelName = "llama3")
     {
         return builder.AddOllama(name, port)
           .AddModel(modelName);

--- a/tests/Aspire.CommunityToolkit.Hosting.Java.Tests/ContainerResourceCreationTests.cs
+++ b/tests/Aspire.CommunityToolkit.Hosting.Java.Tests/ContainerResourceCreationTests.cs
@@ -25,7 +25,8 @@ public class ContainerResourceCreationTests
         IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder();
 
         Assert.Throws<ArgumentNullException>(() => builder.AddJavaApp(null!, new JavaAppContainerResourceOptions()));
-        Assert.Throws<ArgumentException>(() => builder.AddJavaApp("", new JavaAppContainerResourceOptions()));
+        const string name = "";
+        Assert.Throws<ArgumentException>(() => builder.AddJavaApp(name, new JavaAppContainerResourceOptions()));
     }
 
     [Fact]
@@ -34,7 +35,8 @@ public class ContainerResourceCreationTests
         IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder();
 
         Assert.Throws<ArgumentNullException>(() => builder.AddSpringApp(null!, new JavaAppContainerResourceOptions()));
-        Assert.Throws<ArgumentException>(() => builder.AddSpringApp("", new JavaAppContainerResourceOptions()));
+        const string name = "";
+        Assert.Throws<ArgumentException>(() => builder.AddSpringApp(name, new JavaAppContainerResourceOptions()));
     }
 
     [Fact]

--- a/tests/Aspire.CommunityToolkit.Hosting.Java.Tests/ExecutableResourceCreationTests.cs
+++ b/tests/Aspire.CommunityToolkit.Hosting.Java.Tests/ExecutableResourceCreationTests.cs
@@ -26,7 +26,9 @@ public class ExecutableResourceCreationTests
         IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder();
 
         Assert.Throws<ArgumentNullException>(() => builder.AddJavaApp(null!, Environment.CurrentDirectory, new JavaAppExecutableResourceOptions()));
-        Assert.Throws<ArgumentException>(() => builder.AddJavaApp("", Environment.CurrentDirectory, new JavaAppExecutableResourceOptions()));
+
+        const string name = "";
+        Assert.Throws<ArgumentException>(() => builder.AddJavaApp(name, Environment.CurrentDirectory, new JavaAppExecutableResourceOptions()));
     }
 
     [Fact]
@@ -35,7 +37,9 @@ public class ExecutableResourceCreationTests
         IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder();
 
         Assert.Throws<ArgumentNullException>(() => builder.AddSpringApp(null!, Environment.CurrentDirectory, new JavaAppExecutableResourceOptions()));
-        Assert.Throws<ArgumentException>(() => builder.AddSpringApp("", Environment.CurrentDirectory, new JavaAppExecutableResourceOptions()));
+
+        const string name = "";
+        Assert.Throws<ArgumentException>(() => builder.AddSpringApp(name, Environment.CurrentDirectory, new JavaAppExecutableResourceOptions()));
     }
 
     [Fact]

--- a/tests/Aspire.CommunityToolkit.Hosting.Ollama.Tests/AddOllamaTests.cs
+++ b/tests/Aspire.CommunityToolkit.Hosting.Ollama.Tests/AddOllamaTests.cs
@@ -119,9 +119,14 @@ public class AddOllamaTests
     [Fact]
     public void ResourceNameCannotBeOmitted()
     {
-        Assert.Throws<ArgumentException>(() => DistributedApplication.CreateBuilder().AddOllama("", port: null));
-        Assert.Throws<ArgumentException>(() => DistributedApplication.CreateBuilder().AddOllama(" ", port: null));
-        Assert.Throws<ArgumentNullException>(() => DistributedApplication.CreateBuilder().AddOllama(null!, port: null));
+        string name = "";
+        Assert.Throws<ArgumentException>(() => DistributedApplication.CreateBuilder().AddOllama(name, port: null));
+
+        name = " ";
+        Assert.Throws<ArgumentException>(() => DistributedApplication.CreateBuilder().AddOllama(name, port: null));
+
+        name = null!;
+        Assert.Throws<ArgumentNullException>(() => DistributedApplication.CreateBuilder().AddOllama(name, port: null));
     }
 
     [Fact]
@@ -130,9 +135,14 @@ public class AddOllamaTests
         var builder = DistributedApplication.CreateBuilder();
         var ollama = builder.AddOllama("ollama", port: null);
 
-        Assert.Throws<ArgumentException>(() => ollama.AddModel(""));
-        Assert.Throws<ArgumentException>(() => ollama.AddModel(" "));
-        Assert.Throws<ArgumentNullException>(() => ollama.AddModel(null!));
+        string name = "";
+        Assert.Throws<ArgumentException>(() => ollama.AddModel(name));
+
+        name = " ";
+        Assert.Throws<ArgumentException>(() => ollama.AddModel(name));
+
+        name = null!;
+        Assert.Throws<ArgumentNullException>(() => ollama.AddModel(name));
     }
 
     [Fact]
@@ -141,9 +151,14 @@ public class AddOllamaTests
         var builder = DistributedApplication.CreateBuilder();
         var ollama = builder.AddOllama("ollama", port: null);
 
-        Assert.Throws<ArgumentException>(() => ollama.WithDefaultModel(""));
-        Assert.Throws<ArgumentException>(() => ollama.WithDefaultModel(" "));
-        Assert.Throws<ArgumentNullException>(() => ollama.WithDefaultModel(null!));
+        string name = "";
+        Assert.Throws<ArgumentException>(() => ollama.WithDefaultModel(name));
+
+        name = " ";
+        Assert.Throws<ArgumentException>(() => ollama.WithDefaultModel(name));
+
+        name = null!;
+        Assert.Throws<ArgumentNullException>(() => ollama.WithDefaultModel(name));
     }
 
     [Fact]


### PR DESCRIPTION
Does require a bit of hackery in the tests to tell the analyser to be quiet but that's ok.

Fixes #89
