### PR TITLE
Preparing 8.2.1 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,50 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 21
+          days-before-close: 14
+          enable-statistics: true
+          any-of-labels: "Awaiting Response"
+          remove-stale-when-updated: true
+          stale-issue-message: "We have noticed this issue has not been updated within 21 days.  If there is no action on this issue in the next 14 days, we will automatically close it."
+          stale-pr-message: "We have noticed this PR has not been updated within 21 days.  If there is no action on this PR in the next 14 days, we will automatically close it."
+          close-issue-message: "This issue has been stale for 5 weeks and has been automatically closed."
+          close-pr-message: "This PR has been stale for 5 weeks and has been automatically closed."
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 5
+          days-before-close: 2
+          enable-statistics: true
+          only-issue-labels: "Question,Resolved"
+          remove-stale-when-updated: true
+          stale-issue-message: "We have noticed this issue has been resolved for 5 days.  If there is not action on this issue in the next 2 days, we will automatically close it."
+          stale-issue-label: "stale"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,8 +10,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <AspireVersion>8.2.0</AspireVersion>
-    <AspNetCoreVersion>8.0.7</AspNetCoreVersion>
+    <AspireVersion>8.2.1</AspireVersion>
+    <AspNetCoreVersion>8.0.10</AspNetCoreVersion>
     <OpenTelemetryVersion>1.9.0</OpenTelemetryVersion>
     <TestContainersVersion>3.10.0</TestContainersVersion>
     <IsPackable>false</IsPackable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,10 +12,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <!-- .NET packages -->
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" />
@@ -29,15 +29,15 @@
     <!-- Testing packages -->
     <PackageVersion Include="Aspire.Hosting.Testing" Version="$(AspireVersion)" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="xunit" Version="2.9.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="xunit.extensibility.execution" Version="2.9.1" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="2.9.2" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.24516.1" />
     <!-- External packages -->
-    <PackageVersion Include="OllamaSharp" Version="3.0.7" />
+    <PackageVersion Include="OllamaSharp" Version="3.0.15" />
     <PackageVersion Include="MeiliSearch" Version="0.15.3" />
     <!-- Build dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />


### PR DESCRIPTION
With NuGet publishing sorted, it's time to cut a stable release to NuGet.

I've updated our dependencies to use the latest of everything, so Aspire 8.2.1 (current stable), and all additional packages.

To ensure that we can keep up on this stuff I've also added dependabot to do weekly scanning and a stale issue closer (to help clean everything up).