### PR TITLE
Changing versioning for builds

### DIFF
--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Publish NuGet package
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:PackageVersion=${{ steps.git_tag.outputs.tag }}
+        run: dotnet pack --no-build -c ${{ env.DOTNET_CONFIGURATION }} -o ./nuget -p:PackageVersion=${{ steps.git_tag.outputs.tag }} /p:ReleaseBuild=true
 
       - name: Publish NuGet packages as artifacts
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <AspireVersion>8.2.1</AspireVersion>
+    <AspireMajorVersion>8</AspireMajorVersion>
+    <AspireVersion>$(AspireMajorVersion).2.1</AspireVersion>
     <AspNetCoreVersion>8.0.10</AspNetCoreVersion>
     <OpenTelemetryVersion>1.9.0</OpenTelemetryVersion>
     <TestContainersVersion>3.10.0</TestContainersVersion>
@@ -19,6 +20,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+
+    <ToolkitMinorVersion>3</ToolkitMinorVersion>
+    <ToolkitPatchVersion>0</ToolkitPatchVersion>
 </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,4 +4,8 @@
     <VSTestLogger>trx%3BLogFileName=$(AssemblyName)-$(TargetFramework).trx</VSTestLogger>
   </PropertyGroup>
   </Target>
+
+  <Target Name="FailBuildIfReleaseVersionWrong" BeforeTargets="Pack" Condition=" $(ReleaseBuild) == 'true' ">
+    <Error Text="The supplied Version for packaging does not match what version has been used. Expected: '$(AspireMajorVersion).$(ToolkitMinorVersion).$(ToolkitPatchVersion)', received: '$(PackageVersion)'" Condition="'$(PackageVersion)' != '$(AspireMajorVersion).$(ToolkitMinorVersion).$(ToolkitPatchVersion)'" />
+  </Target>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/CommunityToolkit/Aspire</PackageProjectUrl>
     <PackageIcon>nuget.png</PackageIcon>
     <RepositoryUrl>https://github.com/CommunityToolkit/Aspire</RepositoryUrl>
-    <VersionPrefix>$(AspireVersion).0</VersionPrefix>
+    <VersionPrefix>$(AspireMajorVersion).$(ToolkitMinorVersion).$(ToolkitPatchVersion)</VersionPrefix>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Added a failure condition for release builds that if you try to release a version that doesn't match what we'd been building the CI will fail.

![Example of failure](https://github.com/user-attachments/assets/8f5bc1df-9ae4-450f-91ea-5f4587fca962)


Fixes #145
