### PR TITLE
Improving SWA test stability

### DIFF
--- a/tests/CommunityToolkit.Aspire.Hosting.Azure.StaticWebApps.Tests/SwaHostingComponentTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Azure.StaticWebApps.Tests/SwaHostingComponentTests.cs
@@ -13,7 +13,7 @@ public class SwaHostingComponentTests(AspireIntegrationTestFixture<Projects.Comm
     {
         var httpClient = fixture.CreateHttpClient("swa");
 
-        await fixture.App.WaitForTextAsync("Azure Static Web Apps emulator started", "swa").WaitAsync(TimeSpan.FromSeconds(30));
+        await fixture.App.WaitForTextAsync("Azure Static Web Apps emulator started", "swa").WaitAsync(TimeSpan.FromMinutes(5));
 
         var response = await httpClient.GetAsync("/");
 
@@ -25,7 +25,7 @@ public class SwaHostingComponentTests(AspireIntegrationTestFixture<Projects.Comm
     {
         var httpClient = fixture.CreateHttpClient("swa");
 
-        await fixture.App.WaitForTextAsync("Azure Static Web Apps emulator started", "swa").WaitAsync(TimeSpan.FromSeconds(30));
+        await fixture.App.WaitForTextAsync("Azure Static Web Apps emulator started", "swa").WaitAsync(TimeSpan.FromMinutes(5));
 
         var response = await httpClient.GetAsync("/api/weather");
 


### PR DESCRIPTION
I've extended the timeout to 5 minutes as the logs from the issue seem to suggest that it's just timing out trying to setup the resources that the emulator relies on (install npm packages and what not).

Fixes #157
