### PR TITLE
Update `ToolkitMinorVersion` to 0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
 
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
 
-    <ToolkitMinorVersion>3</ToolkitMinorVersion>
+    <ToolkitMinorVersion>0</ToolkitMinorVersion>
     <ToolkitPatchVersion>0</ToolkitPatchVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
`ToolkitMinorVersion` should be zero. we should not skip 9.0.* and 9.1.* versions.

@aaronpowell  What happens in the Nuget feed when we merge this PR?
Will the `9.3.0-beta.52` be listed as the last version?