### PR TITLE
Add Waitfor For Meilisearch

### DIFF
--- a/examples/meilisearch/CommunityToolkit.Aspire.Hosting.Meilisearch.AppHost/Program.cs
+++ b/examples/meilisearch/CommunityToolkit.Aspire.Hosting.Meilisearch.AppHost/Program.cs
@@ -5,6 +5,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var meilisearch = builder.AddMeilisearch("meilisearch");
 
 builder.AddProject<CommunityToolkit_Aspire_Hosting_Meilisearch_ApiService>("apiservice")
-    .WithReference(meilisearch);
+    .WithReference(meilisearch)
+    .WaitFor(meilisearch);
 
 builder.Build().Run();

--- a/src/CommunityToolkit.Aspire.Hosting.Meilisearch/CommunityToolkit.Aspire.Hosting.Meilisearch.csproj
+++ b/src/CommunityToolkit.Aspire.Hosting.Meilisearch/CommunityToolkit.Aspire.Hosting.Meilisearch.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
+    <Compile Include="$(RepoRoot)src\CommunityToolkit.Aspire.Meilisearch\MeilisearchHealthCheck.cs" Link="MeilisearchHealthCheck.cs"></Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CommunityToolkit.Aspire.Hosting.Meilisearch/MeilisearchFunctionalTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Meilisearch/MeilisearchFunctionalTests.cs
@@ -191,44 +191,44 @@ public class MeilisearchFunctionalTests(ITestOutputHelper testOutputHelper)
 
     //following commented section need to aspire 9.0.
 
-    //[Fact]
-    //public async Task VerifyWaitForOnMeilisearchBlocksDependentResources()
-    //{
-    //    var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
-    //    using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+    [Fact]
+    public async Task VerifyWaitForOnMeilisearchBlocksDependentResources()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
-    //    var healthCheckTcs = new TaskCompletionSource<HealthCheckResult>();
-    //    builder.Services.AddHealthChecks().AddAsyncCheck("blocking_check", () =>
-    //    {
-    //        return healthCheckTcs.Task;
-    //    });
+        var healthCheckTcs = new TaskCompletionSource<HealthCheckResult>();
+        builder.Services.AddHealthChecks().AddAsyncCheck("blocking_check", () =>
+        {
+            return healthCheckTcs.Task;
+        });
 
-    //    var resource = builder.AddMeilisearch("resource")
-    //                          .WithHealthCheck("blocking_check");
+        var resource = builder.AddMeilisearch("resource")
+                              .WithHealthCheck("blocking_check");
 
-    //    var dependentResource = builder.AddMeilisearch("dependentresource")
-    //                                   .WaitFor(resource);
+        var dependentResource = builder.AddMeilisearch("dependentresource")
+                                       .WaitFor(resource);
 
-    //    using var app = builder.Build();
+        using var app = builder.Build();
 
-    //    var pendingStart = app.StartAsync(cts.Token);
+        var pendingStart = app.StartAsync(cts.Token);
 
-    //    var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
-    //    await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-    //    await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
-    //    healthCheckTcs.SetResult(HealthCheckResult.Healthy());
+        healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-    //    await rns.WaitForResourceAsync(resource.Resource.Name, re => re.Snapshot.HealthStatus == HealthStatus.Healthy, cts.Token);
+        await rns.WaitForResourceAsync(resource.Resource.Name, re => re.Snapshot.HealthStatus == HealthStatus.Healthy, cts.Token);
 
-    //    await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-    //    await pendingStart;
+        await pendingStart;
 
-    //    await app.StopAsync();
-    //}
+        await app.StopAsync();
+    }
 
     private static async Task CreateTestData(MeilisearchClient meilisearchClient)
     {

--- a/tests/CommunityToolkit.Aspire.Hosting.Meilisearch/MeilisearchFunctionalTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Meilisearch/MeilisearchFunctionalTests.cs
@@ -189,8 +189,6 @@ public class MeilisearchFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
 
-    //following commented section need to aspire 9.0.
-
     [Fact]
     public async Task VerifyWaitForOnMeilisearchBlocksDependentResources()
     {


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

Closes #73 

<!-- Add an overview of the changes here -->
This pull request introduces several enhancements and bug fixes to the `CommunityToolkit.Aspire.Hosting.Meilisearch` project, including the addition of health checks and the reactivation of previously commented-out code. The most important changes are summarized below:

### Enhancements:

* **Health Check Integration**:
  * [`src/CommunityToolkit.Aspire.Hosting.Meilisearch/CommunityToolkit.Aspire.Hosting.Meilisearch.csproj`](diffhunk://#diff-530427004b07ff6537d47fbbdd943b1a6c424fcf837ecfad3838fbe08e4c9104R10): Added `MeilisearchHealthCheck.cs` to the project.
  * [`src/CommunityToolkit.Aspire.Hosting.Meilisearch/MeilisearchBuilderExtensions.cs`](diffhunk://#diff-1890e9aa0335fc3968f6157b0026de41bc8fa62f7be6647cb3b05615a97e6cd2L52-R72): Integrated health checks for Meilisearch resources and ensured the health check key is added to the builder. [[1]](diffhunk://#diff-1890e9aa0335fc3968f6157b0026de41bc8fa62f7be6647cb3b05615a97e6cd2L52-R72) [[2]](diffhunk://#diff-1890e9aa0335fc3968f6157b0026de41bc8fa62f7be6647cb3b05615a97e6cd2L80-R82)

### Bug Fixes:

* **Reactivation of Previously Commented Code**:
  * [`src/CommunityToolkit.Aspire.Hosting.Meilisearch/MeilisearchBuilderExtensions.cs`](diffhunk://#diff-1890e9aa0335fc3968f6157b0026de41bc8fa62f7be6647cb3b05615a97e6cd2L52-R72): Reactivated the subscription to `ConnectionStringAvailableEvent` and health check registration code.
  * [`tests/CommunityToolkit.Aspire.Hosting.Meilisearch/MeilisearchFunctionalTests.cs`](diffhunk://#diff-0aed478053f3ba2271cc2a1fd2b22675006e062004cd531783dad5f18ada8718L194-R231): Reactivated the `VerifyWaitForOnMeilisearchBlocksDependentResources` test to ensure dependent resources wait for Meilisearch health checks.
<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [ ] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->