### PR TITLE
Default Formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.compile.nullAnalysis.mode": "automatic"
+  "java.compile.nullAnalysis.mode": "automatic",
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
When the Deno extension is installed it wants to set the default formatter for all files as itself, which will cause all our files to format differently.

Explicitly setting prettier as the formatter by default, but then other languages (like C#) will fall back to their normal default formatter.
