### PR TITLE
Initialize PublicAPI file generation task in VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,10 +2,18 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Generate PublicAPI files",
       "type": "shell",
-      "label": "docs: serve",
-      "command": "python -m mkdocs serve",
+      "command": "echo '#nullable enable' > src/${input:projectName}/PublicAPI.Shipped.txt && echo '#nullable enable' > src/${input:projectName}/PublicAPI.Unshipped.txt",
       "problemMatcher": []
+    }
+  ],
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "projectName",
+      "description": "Enter the name of the project",
+      "default": "CommunityToolkit.Aspire.MyIntegration"
     }
   ]
 }


### PR DESCRIPTION
Add a VSCode task to generate PublicAPI files with a prompt for the project name.