### PR TITLE
Removing path filters on main and release CI workflows

### DIFF
--- a/.github/workflows/dotnet-main.yml
+++ b/.github/workflows/dotnet-main.yml
@@ -3,11 +3,6 @@ name: .NET main
 on:
   push:
     branches: ["main"]
-    paths:
-      - "src/**"
-      - "examples/**"
-      - "tests/**"
-      - ".github/workflows/dotnet-main.yml"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -4,10 +4,6 @@ on:
   push:
     tags:
       - "v*"
-    paths:
-      - "src/**"
-      - "examples/**"
-      - "tests/**"
 
 env:
   DEFAULT_DOTNET_VERSION: "8.0.x"


### PR DESCRIPTION
These happen on more specific events so we don't want to do filters
