### PR TITLE
Deno integration fix

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: denoland/setup-deno@v2
         name: Setup Deno
         with:
-          deno-version: v2.x
+          deno-version: v2.1.4
 
       - uses: oven-sh/setup-bun@v2
         name: Setup Bun


### PR DESCRIPTION
With #377 we've identified a problem that means that CI is broken for the Deno integration.

Looking at the build logs it seems that Deno 2.1.5 (released in the past week) is causing failures.

This PR pins the version of 2.1.4 for Deno, which is the last known working version. Admittedly, this is a temporary workaround until we find the underlying problem that comes with Deno 2.1.5