### PR TITLE
#405 remove FluentAssertions from ActiveMQ test

### DIFF
--- a/tests/CommunityToolkit.Aspire.Hosting.ActiveMQ.Tests/AppHostTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.ActiveMQ.Tests/AppHostTests.cs
@@ -1,7 +1,6 @@
 using Aspire.Components.Common.Tests;
 using CommunityToolkit.Aspire.Hosting.ActiveMQ.MassTransit;
 using CommunityToolkit.Aspire.Testing;
-using FluentAssertions;
 using System.Net.Http.Json;
 
 namespace CommunityToolkit.Aspire.Hosting.ActiveMQ.Tests;
@@ -18,7 +17,7 @@ public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit
         
         HttpResponseMessage response = await httpClient.PostAsync("/send/Hello%20World", new StringContent(""));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
@@ -30,7 +29,8 @@ public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit
         
         HttpResponseMessage response = await httpClient.PostAsync("/send/Hello%20World", new StringContent(""));
 
-        (await response.Content.ReadAsStringAsync()).Should().Be("I've received your message: Hello World");
+        string message = (await response.Content.ReadAsStringAsync());
+        Assert.Equal("I've received your message: Hello World", message);
     }
 
     [Fact]
@@ -41,14 +41,13 @@ public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit
         HttpClient httpClient = fixture.CreateHttpClient(resourceName);
         
         MessageCounter? oldMessageCounter = await httpClient.GetFromJsonAsync<MessageCounter>("/received");
-        oldMessageCounter.Should().NotBeNull();
+        Assert.NotNull(oldMessageCounter);
         
         await httpClient.PostAsync("/send/Hello%20World", new StringContent(""));
 
-        MessageCounter? messageCounter = null;
-        messageCounter = await httpClient.GetFromJsonAsync<MessageCounter>("/received");
+        MessageCounter? messageCounter = await httpClient.GetFromJsonAsync<MessageCounter>("/received");
 
-        messageCounter.Should().NotBeNull();
-        messageCounter!.ReceivedMessages.Should().BeGreaterThan(oldMessageCounter!.ReceivedMessages);
+        Assert.NotNull(messageCounter);
+        Assert.True(messageCounter.ReceivedMessages > oldMessageCounter.ReceivedMessages);
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Contributes to #405**

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Contains **NO** breaking changes
- [X] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

Just a small part of removing FluentAssertions

<!-- Please add any other information that might be helpful to reviewers. -->