### PR TITLE
Adding ability to configure extensions for Sqlite

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,6 @@
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(DotNetExtensionsVersion)" />
-    <PackageVersion Include="mod_spatialite" Version="4.3.0.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <!-- .NET packages -->
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(DotNetExtensionsVersion)" />
@@ -55,6 +54,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.9.2" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version=" 9.0.0-beta.24568.1" />
+    <PackageVersion Include="mod_spatialite" Version="4.3.0.1" />
     <!-- External packages -->
     <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(DotNetExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(DotNetExtensionsVersion)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <!-- .NET packages -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(DotNetExtensionsVersion)" />
+    <PackageVersion Include="mod_spatialite" Version="4.3.0.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <!-- .NET packages -->
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(DotNetExtensionsVersion)" />

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -10,3 +10,6 @@ In these cases, refer to the `<remarks>` docs section of the API for more inform
 
 Once a release of .NET Aspire with that API is available, the API in the .NET Aspire Community Toolkit will be marked as obsolete and will be removed in a future release.
 
+## CTASPIRE002
+
+Support for loading extensions into SQLite requires either a NuGet package or folder path to the library to be provided, and as a result there is some custom logic to load the extension based on the path or NuGet package. This logic will require some experimenting to figure out edge cases, so the feature for extension loading will be kept as experimental until it is proven to be stable.

--- a/nuget.config
+++ b/nuget.config
@@ -8,7 +8,7 @@
   </packageSources>
   <packageSourceMapping>
     <packageSource key="dotnet-eng">
-      <package pattern="Microsoft.DotNet.*" />
+      <package pattern="Microsoft.DotNet.XUnitExtensions" />
     </packageSource>
     <packageSource key="nuget">
       <package pattern="*" />

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/CommunityToolkit.Aspire.Hosting.Sqlite.csproj
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/CommunityToolkit.Aspire.Hosting.Sqlite.csproj
@@ -11,4 +11,8 @@
   <ItemGroup>
     <InternalsVisibleTo Include="CommunityToolkit.Aspire.Hosting.Sqlite.Tests"></InternalsVisibleTo>
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SharedDir)\Sqlite\SqliteExtensionMetadata.cs" Link="Utils\Sqlite\SqliteExtensionMetadata.cs" />
+  </ItemGroup>
 </Project>

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/PublicAPI.Unshipped.txt
@@ -1,17 +1,7 @@
 #nullable enable
-Aspire.Hosting.ApplicationModel.ExtensionMetadata
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.Extension.get -> string!
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.Extension.init -> void
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.ExtensionFolder.get -> string?
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.ExtensionFolder.init -> void
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.ExtensionMetadata(string! Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder) -> void
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.IsNuGetPackage.get -> bool
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.IsNuGetPackage.init -> void
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.PackageName.get -> string?
-Aspire.Hosting.ApplicationModel.ExtensionMetadata.PackageName.init -> void
 Aspire.Hosting.ApplicationModel.SqliteResource
 Aspire.Hosting.ApplicationModel.SqliteResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
-Aspire.Hosting.ApplicationModel.SqliteResource.Extensions.get -> System.Collections.Generic.IReadOnlyCollection<Aspire.Hosting.ApplicationModel.ExtensionMetadata!>!
+Aspire.Hosting.ApplicationModel.SqliteResource.Extensions.get -> System.Collections.Generic.IReadOnlyCollection<Microsoft.Extensions.Hosting.SqliteExtensionMetadata!>!
 Aspire.Hosting.ApplicationModel.SqliteResource.SqliteResource(string! name, string! databasePath, string! databaseFileName) -> void
 Aspire.Hosting.ApplicationModel.SqliteWebResource
 Aspire.Hosting.ApplicationModel.SqliteWebResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
@@ -22,3 +12,13 @@ static Aspire.Hosting.SqliteResourceBuilderExtensions.AddSqlite(this Aspire.Host
 static Aspire.Hosting.SqliteResourceBuilderExtensions.WithLocalExtension(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string! extension, string! extensionPath) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
 static Aspire.Hosting.SqliteResourceBuilderExtensions.WithNuGetExtension(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string! extension, string? packageName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
 static Aspire.Hosting.SqliteResourceBuilderExtensions.WithSqliteWeb(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string? containerName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.Extension.get -> string!
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.Extension.init -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.ExtensionFolder.get -> string?
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.ExtensionFolder.init -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.IsNuGetPackage.get -> bool
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.IsNuGetPackage.init -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.PackageName.get -> string?
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.PackageName.init -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.SqliteExtensionMetadata(string! Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder) -> void

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/PublicAPI.Unshipped.txt
@@ -1,7 +1,17 @@
 #nullable enable
+Aspire.Hosting.ApplicationModel.ExtensionMetadata
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.Extension.get -> string!
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.Extension.init -> void
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.ExtensionFolder.get -> string?
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.ExtensionFolder.init -> void
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.ExtensionMetadata(string! Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder) -> void
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.IsNuGetPackage.get -> bool
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.IsNuGetPackage.init -> void
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.PackageName.get -> string?
+Aspire.Hosting.ApplicationModel.ExtensionMetadata.PackageName.init -> void
 Aspire.Hosting.ApplicationModel.SqliteResource
 Aspire.Hosting.ApplicationModel.SqliteResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
-Aspire.Hosting.ApplicationModel.SqliteResource.Extensions.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Aspire.Hosting.ApplicationModel.SqliteResource.Extensions.get -> System.Collections.Generic.IReadOnlyCollection<Aspire.Hosting.ApplicationModel.ExtensionMetadata!>!
 Aspire.Hosting.ApplicationModel.SqliteResource.SqliteResource(string! name, string! databasePath, string! databaseFileName) -> void
 Aspire.Hosting.ApplicationModel.SqliteWebResource
 Aspire.Hosting.ApplicationModel.SqliteWebResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
@@ -9,5 +19,6 @@ Aspire.Hosting.ApplicationModel.SqliteWebResource.PrimaryEndpoint.get -> Aspire.
 Aspire.Hosting.ApplicationModel.SqliteWebResource.SqliteWebResource(string! name) -> void
 Aspire.Hosting.SqliteResourceBuilderExtensions
 static Aspire.Hosting.SqliteResourceBuilderExtensions.AddSqlite(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string? databasePath = null, string? databaseFileName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
-static Aspire.Hosting.SqliteResourceBuilderExtensions.WithExtension(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string! extension) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
+static Aspire.Hosting.SqliteResourceBuilderExtensions.WithLocalExtension(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string! extension, string! extensionPath) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
+static Aspire.Hosting.SqliteResourceBuilderExtensions.WithNuGetExtension(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string! extension, string? packageName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
 static Aspire.Hosting.SqliteResourceBuilderExtensions.WithSqliteWeb(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string? containerName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Aspire.Hosting.ApplicationModel.SqliteResource
 Aspire.Hosting.ApplicationModel.SqliteResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
+Aspire.Hosting.ApplicationModel.SqliteResource.Extensions.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 Aspire.Hosting.ApplicationModel.SqliteResource.SqliteResource(string! name, string! databasePath, string! databaseFileName) -> void
 Aspire.Hosting.ApplicationModel.SqliteWebResource
 Aspire.Hosting.ApplicationModel.SqliteWebResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
@@ -8,4 +9,5 @@ Aspire.Hosting.ApplicationModel.SqliteWebResource.PrimaryEndpoint.get -> Aspire.
 Aspire.Hosting.ApplicationModel.SqliteWebResource.SqliteWebResource(string! name) -> void
 Aspire.Hosting.SqliteResourceBuilderExtensions
 static Aspire.Hosting.SqliteResourceBuilderExtensions.AddSqlite(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string? databasePath = null, string? databaseFileName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
+static Aspire.Hosting.SqliteResourceBuilderExtensions.WithExtension(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string! extension) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!
 static Aspire.Hosting.SqliteResourceBuilderExtensions.WithSqliteWeb(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>! builder, string? containerName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqliteResource!>!

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResource.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResource.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -15,5 +17,17 @@ public class SqliteResource(string name, string databasePath, string databaseFil
     internal string DatabaseFilePath => Path.Combine(DatabasePath, DatabaseFileName);
 
     /// <inheritdoc/>
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"Data Source={DatabaseFilePath};Cache=Shared;Mode=ReadWriteCreate;");
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"Data Source={DatabaseFilePath};Cache=Shared;Mode=ReadWriteCreate;Extensions={JsonSerializer.Serialize(Extensions)}");
+
+    private readonly List<string> extensions = [];
+
+    /// <summary>
+    /// Gets the extensions to be loaded into the database.
+    /// </summary>
+    /// <remarks>
+    /// Extensions are not loaded by the hosting integration, the information is provided for the client to load the extensions.
+    /// </remarks>
+    public IReadOnlyCollection<string> Extensions => extensions;
+
+    internal void AddExtension(string extension) => extensions.Add(extension);
 }

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResource.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResource.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Hosting;
 using System.Text.Json;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -19,7 +20,7 @@ public class SqliteResource(string name, string databasePath, string databaseFil
     /// <inheritdoc/>
     public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"Data Source={DatabaseFilePath};Cache=Shared;Mode=ReadWriteCreate;Extensions={JsonSerializer.Serialize(Extensions)}");
 
-    private readonly List<ExtensionMetadata> extensions = [];
+    private readonly List<SqliteExtensionMetadata> extensions = [];
 
     /// <summary>
     /// Gets the extensions to be loaded into the database.
@@ -27,16 +28,8 @@ public class SqliteResource(string name, string databasePath, string databaseFil
     /// <remarks>
     /// Extensions are not loaded by the hosting integration, the information is provided for the client to load the extensions.
     /// </remarks>
-    public IReadOnlyCollection<ExtensionMetadata> Extensions => extensions;
+    public IReadOnlyCollection<SqliteExtensionMetadata> Extensions => extensions;
 
-    internal void AddExtension(ExtensionMetadata extension) => extensions.Add(extension);
+    internal void AddExtension(SqliteExtensionMetadata extension) => extensions.Add(extension);
 }
 
-/// <summary>
-/// Represents metadata for an extension to be loaded into a database.
-/// </summary>
-/// <param name="Extension">The name of the extension binary, eg: vec0</param>
-/// <param name="PackageName">The name of the NuGet package. Only required if <paramref name="IsNuGetPackage"/> is <see langword="true" />.</param>
-/// <param name="IsNuGetPackage">Indicates if the extension will be loaded from a NuGet package.</param>
-/// <param name="ExtensionFolder">The folder for the extension. Only required if <paramref name="IsNuGetPackage"/> is <see langword="false" />.</param>
-public record ExtensionMetadata(string Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder);

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResource.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResource.cs
@@ -19,7 +19,7 @@ public class SqliteResource(string name, string databasePath, string databaseFil
     /// <inheritdoc/>
     public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"Data Source={DatabaseFilePath};Cache=Shared;Mode=ReadWriteCreate;Extensions={JsonSerializer.Serialize(Extensions)}");
 
-    private readonly List<string> extensions = [];
+    private readonly List<ExtensionMetadata> extensions = [];
 
     /// <summary>
     /// Gets the extensions to be loaded into the database.
@@ -27,7 +27,16 @@ public class SqliteResource(string name, string databasePath, string databaseFil
     /// <remarks>
     /// Extensions are not loaded by the hosting integration, the information is provided for the client to load the extensions.
     /// </remarks>
-    public IReadOnlyCollection<string> Extensions => extensions;
+    public IReadOnlyCollection<ExtensionMetadata> Extensions => extensions;
 
-    internal void AddExtension(string extension) => extensions.Add(extension);
+    internal void AddExtension(ExtensionMetadata extension) => extensions.Add(extension);
 }
+
+/// <summary>
+/// Represents metadata for an extension to be loaded into a database.
+/// </summary>
+/// <param name="Extension">The name of the extension binary, eg: vec0</param>
+/// <param name="PackageName">The name of the NuGet package. Only required if <paramref name="IsNuGetPackage"/> is <see langword="true" />.</param>
+/// <param name="IsNuGetPackage">Indicates if the extension will be loaded from a NuGet package.</param>
+/// <param name="ExtensionFolder">The folder for the extension. Only required if <paramref name="IsNuGetPackage"/> is <see langword="false" />.</param>
+public record ExtensionMetadata(string Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder);

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResourceBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResourceBuilderExtensions.cs
@@ -85,4 +85,21 @@ public static class SqliteResourceBuilderExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Adds an extension to the Sqlite resource.
+    /// </summary>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="extension">The extension to add.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>Extensions are not loaded by the hosting integration, the information is provided for the client to load the extensions.</remarks>
+    public static IResourceBuilder<SqliteResource> WithExtension(this IResourceBuilder<SqliteResource> builder, string extension)
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        ArgumentNullException.ThrowIfNull(extension, nameof(extension));
+
+        builder.Resource.AddExtension(extension);
+
+        return builder;
+    }
 }

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResourceBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResourceBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Aspire.Hosting.ApplicationModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting;
 
@@ -87,18 +88,48 @@ public static class SqliteResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds an extension to the Sqlite resource.
+    /// Adds an extension to the Sqlite resource that will be loaded from a NuGet package.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="extension">The extension to add.</param>
+    /// <param name="extension">The name of the extension file with to add, eg: vec0, without file extension.</param>
+    /// <param name="packageName">The name of the NuGet package. If this is set to null, the value of <paramref name="extension"/> is used.</param>
     /// <returns>The resource builder.</returns>
-    /// <remarks>Extensions are not loaded by the hosting integration, the information is provided for the client to load the extensions.</remarks>
-    public static IResourceBuilder<SqliteResource> WithExtension(this IResourceBuilder<SqliteResource> builder, string extension)
+    /// <remarks>
+    /// Extensions are not loaded by the hosting integration, the information is provided for the client to load the extensions.
+    /// 
+    /// This extension is experimental while the final design of extension loading is decided.
+    /// </remarks>
+    [Experimental("CTASPIRE002", UrlFormat = "https://aka.ms/communitytoolkit/aspire/diagnostics#{0}")]
+    public static IResourceBuilder<SqliteResource> WithNuGetExtension(this IResourceBuilder<SqliteResource> builder, string extension, string? packageName = null)
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
-        ArgumentNullException.ThrowIfNull(extension, nameof(extension));
+        ArgumentException.ThrowIfNullOrEmpty(extension, nameof(extension));
 
-        builder.Resource.AddExtension(extension);
+        builder.Resource.AddExtension(new(extension, packageName ?? extension, IsNuGetPackage: true, ExtensionFolder: null));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an extension to the Sqlite resource that will be loaded from a local path.
+    /// </summary>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="extension">The name of the extension file with to add, eg: vec0, without file extension.</param>
+    /// <param name="extensionPath">The path to the extension file.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>
+    /// Extensions are not loaded by the hosting integration, the information is provided for the client to load the extensions.
+    /// 
+    /// This extension is experimental while the final design of extension loading is decided.
+    /// </remarks>    find . -type f -name "*.orig" -delete
+    [Experimental("CTASPIRE002", UrlFormat = "https://aka.ms/communitytoolkit/aspire/diagnostics#{0}")]
+    public static IResourceBuilder<SqliteResource> WithLocalExtension(this IResourceBuilder<SqliteResource> builder, string extension, string extensionPath)
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        ArgumentException.ThrowIfNullOrEmpty(extension, nameof(extension));
+        ArgumentException.ThrowIfNullOrEmpty(extensionPath, nameof(extensionPath));
+
+        builder.Resource.AddExtension(new(extension, PackageName: null, IsNuGetPackage: false, extensionPath));
 
         return builder;
     }

--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResourceBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResourceBuilderExtensions.cs
@@ -121,7 +121,7 @@ public static class SqliteResourceBuilderExtensions
     /// Extensions are not loaded by the hosting integration, the information is provided for the client to load the extensions.
     /// 
     /// This extension is experimental while the final design of extension loading is decided.
-    /// </remarks>    find . -type f -name "*.orig" -delete
+    /// </remarks>
     [Experimental("CTASPIRE002", UrlFormat = "https://aka.ms/communitytoolkit/aspire/diagnostics#{0}")]
     public static IResourceBuilder<SqliteResource> WithLocalExtension(this IResourceBuilder<SqliteResource> builder, string extension, string extensionPath)
     {

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
@@ -249,7 +249,11 @@ public static class AspireSqliteExtensions
             var path = new HashSet<string>(Environment.GetEnvironmentVariable(pathVariableName)!.Split(Path.PathSeparator));
 
             if (assetDirectory is not null && path.Add(assetDirectory))
+            {
+                logger.LogInformation("Adding {AssetDirectory} to {PathVariableName}", assetDirectory, pathVariableName);
                 Environment.SetEnvironmentVariable(pathVariableName, string.Join(Path.PathSeparator, path));
+                logger.LogInformation("Set {PathVariableName} to: {PathVariableValue}", pathVariableName, Environment.GetEnvironmentVariable(pathVariableName));
+            }
         }
         else
         {

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
@@ -3,9 +3,12 @@ using HealthChecks.Sqlite;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Data.Common;
+using System.Runtime.InteropServices;
 using System.Text.Json;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -116,10 +119,103 @@ public static class AspireSqliteExtensions
 
             foreach (var extension in settings.Extensions)
             {
+                EnsureLoadable(extension, extension);
                 connection.LoadExtension(extension);
             }
 
             return connection;
+        }
+    }
+
+    // Adapted from https://github.com/dotnet/docs/blob/dbbeda13bf016a6ff76b0baab1488c927a64ff24/samples/snippets/standard/data/sqlite/ExtensionsSample/Program.cs#L40
+    internal static void EnsureLoadable(string package, string library)
+    {
+        var runtimeLibrary = DependencyContext.Default?.RuntimeLibraries.FirstOrDefault(l => l.Name == package);
+        if (runtimeLibrary is null)
+            return;
+
+        string sharedLibraryExtension;
+        string pathVariableName = "PATH";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            sharedLibraryExtension = ".dll";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            sharedLibraryExtension = ".so";
+            pathVariableName = "LD_LIBRARY_PATH";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            sharedLibraryExtension = ".dylib";
+            pathVariableName = "DYLD_LIBRARY_PATH";
+        }
+        else
+        {
+            throw new NotSupportedException("Unsupported OS platform");
+        }
+
+        var candidateAssets = new Dictionary<(string? Package, string Asset), int>();
+        var rid = RuntimeEnvironment.GetRuntimeIdentifier();
+        var rids = DependencyContext.Default?.RuntimeGraph.First(g => g.Runtime == rid).Fallbacks.ToList() ?? [];
+        rids.Insert(0, rid);
+
+        foreach (var group in runtimeLibrary.NativeLibraryGroups)
+        {
+            foreach (var file in group.RuntimeFiles)
+            {
+                if (string.Equals(
+                    Path.GetFileName(file.Path),
+                    library + sharedLibraryExtension,
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    var fallbacks = rids.IndexOf(group.Runtime);
+                    if (fallbacks != -1)
+                    {
+                        candidateAssets.Add((runtimeLibrary.Path, file.Path), fallbacks);
+                    }
+                }
+            }
+        }
+
+        var assetPath = candidateAssets
+            .OrderBy(p => p.Value)
+            .Select(p => p.Key)
+            .FirstOrDefault();
+        if (assetPath != default)
+        {
+            string? assetDirectory = null;
+            if (File.Exists(Path.Combine(AppContext.BaseDirectory, assetPath.Asset)))
+            {
+                // NB: Framework-dependent deployments copy assets to the application base directory
+                assetDirectory = Path.Combine(
+                    AppContext.BaseDirectory,
+                    Path.GetDirectoryName(assetPath.Asset.Replace('/', Path.DirectorySeparatorChar))!);
+            }
+            else
+            {
+                string? assetFullPath = null;
+                var probingDirectories = ((string?)AppDomain.CurrentDomain.GetData("PROBING_DIRECTORIES"))?
+                    .Split(Path.PathSeparator) ?? [];
+                foreach (var directory in probingDirectories)
+                {
+                    var candidateFullPath = Path.Combine(
+                        directory,
+                        assetPath.Package ?? "",
+                        assetPath.Asset);
+                    if (File.Exists(candidateFullPath))
+                    {
+                        assetFullPath = candidateFullPath;
+                    }
+                }
+
+                assetDirectory = Path.GetDirectoryName(assetFullPath);
+            }
+
+            var path = new HashSet<string>(Environment.GetEnvironmentVariable(pathVariableName)!.Split(Path.PathSeparator));
+
+            if (assetDirectory is not null && path.Add(assetDirectory))
+                Environment.SetEnvironmentVariable(pathVariableName, string.Join(Path.PathSeparator, path));
         }
     }
 }

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
@@ -243,7 +243,7 @@ public static class AspireSqliteExtensions
                 }
 
                 assetDirectory = Path.GetDirectoryName(assetFullPath);
-                logger.LogInformation("Found {Library} in {Package} runtime assets at {Path}", library, package, assetFullPath);
+                logger.LogInformation("Found {Library} in {Package} runtime assets at {Path} (using PROBING_DIRECTORIES: {ProbingDirectories})", library, package, assetFullPath, string.Join(",", probingDirectories));
             }
 
             var path = new HashSet<string>(Environment.GetEnvironmentVariable(pathVariableName)!.Split(Path.PathSeparator));

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
@@ -71,7 +71,7 @@ public static class AspireSqliteExtensions
             var cbs = new DbConnectionStringBuilder { ConnectionString = settings.ConnectionString };
             if (cbs.TryGetValue("Extensions", out var extensions))
             {
-                settings.Extensions = JsonSerializer.Deserialize<IEnumerable<ExtensionMetadata>>((string)extensions) ?? [];
+                settings.Extensions = JsonSerializer.Deserialize<IEnumerable<SqliteExtensionMetadata>>((string)extensions) ?? [];
             }
         }
 

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/AspireSqliteExtensions.cs
@@ -115,7 +115,12 @@ public static class AspireSqliteExtensions
         SqliteConnection CreateConnection(IServiceProvider sp, object? key)
         {
             ConnectionStringValidation.ValidateConnectionString(settings.ConnectionString, connectionName, DefaultConfigSectionName);
-            var connection = new SqliteConnection(settings.ConnectionString);
+            var csb = new DbConnectionStringBuilder { ConnectionString = settings.ConnectionString };
+            if (csb.ContainsKey("Extensions"))
+            {
+                csb.Remove("Extensions");
+            }
+            var connection = new SqliteConnection(csb.ConnectionString);
 
             foreach (var extension in settings.Extensions)
             {

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.csproj
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <Compile Include="$(SharedDir)\HealthChecksExtensions.cs" Link="Utils\HealthChecksExtensions.cs" />
     <Compile Include="$(SharedDir)\ConnectionStringValidation.cs" Link="Utils\ConnectionStringValidation.cs" />
+    <Compile Include="$(SharedDir)\Sqlite\SqliteExtensionMetadata.cs" Link="Utils\Sqlite\SqliteExtensionMetadata.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.csproj
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Sqlite" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/PublicAPI.Unshipped.txt
@@ -1,11 +1,21 @@
 #nullable enable
 Microsoft.Extensions.Hosting.AspireSqliteExtensions
+Microsoft.Extensions.Hosting.ExtensionMetadata
+Microsoft.Extensions.Hosting.ExtensionMetadata.Extension.get -> string!
+Microsoft.Extensions.Hosting.ExtensionMetadata.Extension.init -> void
+Microsoft.Extensions.Hosting.ExtensionMetadata.ExtensionFolder.get -> string?
+Microsoft.Extensions.Hosting.ExtensionMetadata.ExtensionFolder.init -> void
+Microsoft.Extensions.Hosting.ExtensionMetadata.ExtensionMetadata(string! Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder) -> void
+Microsoft.Extensions.Hosting.ExtensionMetadata.IsNuGetPackage.get -> bool
+Microsoft.Extensions.Hosting.ExtensionMetadata.IsNuGetPackage.init -> void
+Microsoft.Extensions.Hosting.ExtensionMetadata.PackageName.get -> string?
+Microsoft.Extensions.Hosting.ExtensionMetadata.PackageName.init -> void
 Microsoft.Extensions.Hosting.SqliteConnectionSettings
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.ConnectionString.get -> string?
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.ConnectionString.set -> void
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.DisableHealthChecks.get -> bool
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.DisableHealthChecks.set -> void
-Microsoft.Extensions.Hosting.SqliteConnectionSettings.Extensions.get -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Extensions.Hosting.SqliteConnectionSettings.Extensions.get -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Hosting.ExtensionMetadata!>!
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.Extensions.set -> void
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.SqliteConnectionSettings() -> void
 static Microsoft.Extensions.Hosting.AspireSqliteExtensions.AddKeyedSqliteConnection(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! name, System.Action<Microsoft.Extensions.Hosting.SqliteConnectionSettings!>? configureSettings = null) -> void

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/PublicAPI.Unshipped.txt
@@ -1,22 +1,22 @@
 #nullable enable
 Microsoft.Extensions.Hosting.AspireSqliteExtensions
-Microsoft.Extensions.Hosting.ExtensionMetadata
-Microsoft.Extensions.Hosting.ExtensionMetadata.Extension.get -> string!
-Microsoft.Extensions.Hosting.ExtensionMetadata.Extension.init -> void
-Microsoft.Extensions.Hosting.ExtensionMetadata.ExtensionFolder.get -> string?
-Microsoft.Extensions.Hosting.ExtensionMetadata.ExtensionFolder.init -> void
-Microsoft.Extensions.Hosting.ExtensionMetadata.ExtensionMetadata(string! Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder) -> void
-Microsoft.Extensions.Hosting.ExtensionMetadata.IsNuGetPackage.get -> bool
-Microsoft.Extensions.Hosting.ExtensionMetadata.IsNuGetPackage.init -> void
-Microsoft.Extensions.Hosting.ExtensionMetadata.PackageName.get -> string?
-Microsoft.Extensions.Hosting.ExtensionMetadata.PackageName.init -> void
 Microsoft.Extensions.Hosting.SqliteConnectionSettings
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.ConnectionString.get -> string?
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.ConnectionString.set -> void
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.DisableHealthChecks.get -> bool
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.DisableHealthChecks.set -> void
-Microsoft.Extensions.Hosting.SqliteConnectionSettings.Extensions.get -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Hosting.ExtensionMetadata!>!
+Microsoft.Extensions.Hosting.SqliteConnectionSettings.Extensions.get -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Hosting.SqliteExtensionMetadata!>!
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.Extensions.set -> void
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.SqliteConnectionSettings() -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.Extension.get -> string!
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.Extension.init -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.ExtensionFolder.get -> string?
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.ExtensionFolder.init -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.IsNuGetPackage.get -> bool
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.IsNuGetPackage.init -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.PackageName.get -> string?
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.PackageName.init -> void
+Microsoft.Extensions.Hosting.SqliteExtensionMetadata.SqliteExtensionMetadata(string! Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder) -> void
 static Microsoft.Extensions.Hosting.AspireSqliteExtensions.AddKeyedSqliteConnection(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! name, System.Action<Microsoft.Extensions.Hosting.SqliteConnectionSettings!>? configureSettings = null) -> void
 static Microsoft.Extensions.Hosting.AspireSqliteExtensions.AddSqliteConnection(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! name, System.Action<Microsoft.Extensions.Hosting.SqliteConnectionSettings!>? configureSettings = null) -> void

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/PublicAPI.Unshipped.txt
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ Microsoft.Extensions.Hosting.SqliteConnectionSettings.ConnectionString.get -> st
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.ConnectionString.set -> void
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.DisableHealthChecks.get -> bool
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.DisableHealthChecks.set -> void
+Microsoft.Extensions.Hosting.SqliteConnectionSettings.Extensions.get -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Extensions.Hosting.SqliteConnectionSettings.Extensions.set -> void
 Microsoft.Extensions.Hosting.SqliteConnectionSettings.SqliteConnectionSettings() -> void
 static Microsoft.Extensions.Hosting.AspireSqliteExtensions.AddKeyedSqliteConnection(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! name, System.Action<Microsoft.Extensions.Hosting.SqliteConnectionSettings!>? configureSettings = null) -> void
 static Microsoft.Extensions.Hosting.AspireSqliteExtensions.AddSqliteConnection(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! name, System.Action<Microsoft.Extensions.Hosting.SqliteConnectionSettings!>? configureSettings = null) -> void

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/SqliteConnectionSettings.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/SqliteConnectionSettings.cs
@@ -21,14 +21,5 @@ public sealed class SqliteConnectionSettings
     /// <summary>
     /// Extensions to be loaded into the database.
     /// </summary>
-    public IEnumerable<ExtensionMetadata> Extensions { get; set; } = [];
+    public IEnumerable<SqliteExtensionMetadata> Extensions { get; set; } = [];
 }
-
-/// <summary>
-/// Represents metadata for an extension to be loaded into a database.
-/// </summary>
-/// <param name="Extension">The name of the extension binary, eg: vec0</param>
-/// <param name="PackageName">The name of the NuGet package. Only required if <paramref name="IsNuGetPackage"/> is <see langword="true" />.</param>
-/// <param name="IsNuGetPackage">Indicates if the extension will be loaded from a NuGet package.</param>
-/// <param name="ExtensionFolder">The folder for the extension. Only required if <paramref name="IsNuGetPackage"/> is <see langword="false" />.</param>
-public record ExtensionMetadata(string Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder);

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/SqliteConnectionSettings.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/SqliteConnectionSettings.cs
@@ -17,4 +17,9 @@ public sealed class SqliteConnectionSettings
     /// The default value is <see langword="false"/>.
     /// </value>
     public bool DisableHealthChecks { get; set; }
+
+    /// <summary>
+    /// Extensions to be loaded into the database.
+    /// </summary>
+    public IEnumerable<string> Extensions { get; set; } = [];
 }

--- a/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/SqliteConnectionSettings.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.Data.Sqlite/SqliteConnectionSettings.cs
@@ -21,5 +21,14 @@ public sealed class SqliteConnectionSettings
     /// <summary>
     /// Extensions to be loaded into the database.
     /// </summary>
-    public IEnumerable<string> Extensions { get; set; } = [];
+    public IEnumerable<ExtensionMetadata> Extensions { get; set; } = [];
 }
+
+/// <summary>
+/// Represents metadata for an extension to be loaded into a database.
+/// </summary>
+/// <param name="Extension">The name of the extension binary, eg: vec0</param>
+/// <param name="PackageName">The name of the NuGet package. Only required if <paramref name="IsNuGetPackage"/> is <see langword="true" />.</param>
+/// <param name="IsNuGetPackage">Indicates if the extension will be loaded from a NuGet package.</param>
+/// <param name="ExtensionFolder">The folder for the extension. Only required if <paramref name="IsNuGetPackage"/> is <see langword="false" />.</param>
+public record ExtensionMetadata(string Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder);

--- a/src/CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite/AspireEFSqliteExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite/AspireEFSqliteExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using Aspire;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.Hosting;
@@ -67,7 +69,13 @@ public static class AspireEFSqliteExtensions
             // delay validating the ConnectionString until the DbContext is requested. This ensures an exception doesn't happen until a Logger is established.
             ConnectionStringValidation.ValidateConnectionString(settings.ConnectionString, name, DefaultConfigSectionName, $"{DefaultConfigSectionName}:{typeof(TContext).Name}", isEfDesignTime: EF.IsDesignTime);
 
-            dbContextOptionsBuilder.UseSqlite(settings.ConnectionString);
+            var csb = new DbConnectionStringBuilder { ConnectionString = settings.ConnectionString };
+            if (csb.ContainsKey("Extensions"))
+            {
+                csb.Remove("Extensions");
+            }
+
+            dbContextOptionsBuilder.UseSqlite(csb.ConnectionString);
             configureDbContextOptions?.Invoke(dbContextOptionsBuilder);
         }
     }

--- a/src/Shared/Sqlite/SqliteExtensionMetadata.cs
+++ b/src/Shared/Sqlite/SqliteExtensionMetadata.cs
@@ -1,0 +1,10 @@
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Represents metadata for an extension to be loaded into a database.
+/// </summary>
+/// <param name="Extension">The name of the extension binary, eg: vec0</param>
+/// <param name="PackageName">The name of the NuGet package. Only required if <paramref name="IsNuGetPackage"/> is <see langword="true" />.</param>
+/// <param name="IsNuGetPackage">Indicates if the extension will be loaded from a NuGet package.</param>
+/// <param name="ExtensionFolder">The folder for the extension. Only required if <paramref name="IsNuGetPackage"/> is <see langword="false" />.</param>
+public record SqliteExtensionMetadata(string Extension, string? PackageName, bool IsNuGetPackage, string? ExtensionFolder);

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AddSqliteTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AddSqliteTests.cs
@@ -102,7 +102,7 @@ public class AddSqliteTests
 
         var connectionString = await sqlite.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
 
-        Assert.Equal($"Data Source={sqlite.Resource.DatabaseFilePath};Cache=Shared;Mode=ReadWriteCreate;", connectionString);
+        Assert.Equal($"Data Source={sqlite.Resource.DatabaseFilePath};Cache=Shared;Mode=ReadWriteCreate;Extensions=[]", connectionString);
     }
 
     [Fact]

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AddSqliteTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AddSqliteTests.cs
@@ -134,4 +134,28 @@ public class AddSqliteTests
         Assert.Equal(sqlite.Resource.DatabasePath, bindMountAnnotation.Source);
         Assert.Equal("/data", bindMountAnnotation.Target);
     }
+
+    [Fact]
+    public void ResourceWithExtension()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var sqlite = builder.AddSqlite("sqlite")
+            .WithExtension("FTS5");
+
+        Assert.Contains("FTS5", sqlite.Resource.Extensions);
+    }
+
+    [Fact]
+    public async Task ConnectionStringContainsExtensions()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var sqlite = builder.AddSqlite("sqlite")
+            .WithExtension("FTS5")
+            .WithExtension("mod_spatialite");
+
+        var connectionString = await sqlite.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
+
+        Assert.Contains("FTS5", connectionString);
+        Assert.Contains("mod_spatialite", connectionString);
+    }
 }

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AddSqliteTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AddSqliteTests.cs
@@ -1,7 +1,7 @@
 ﻿using Aspire.Hosting;
 
 namespace CommunityToolkit.Aspire.Hosting.Sqlite;
-
+#pragma warning disable CTASPIRE002
 public class AddSqliteTests
 {
     [Fact]
@@ -136,13 +136,23 @@ public class AddSqliteTests
     }
 
     [Fact]
-    public void ResourceWithExtension()
+    public void ResourceWithExtensionFromNuGet()
     {
         var builder = DistributedApplication.CreateBuilder();
         var sqlite = builder.AddSqlite("sqlite")
-            .WithExtension("FTS5");
+            .WithNuGetExtension("FTS5");
 
-        Assert.Contains("FTS5", sqlite.Resource.Extensions);
+        Assert.Single(sqlite.Resource.Extensions, static e => e.Extension == "FTS5" && e.PackageName == "FTS5" && e.IsNuGetPackage && e.ExtensionFolder is null);
+    }
+
+    [Fact]
+    public void ResourceWithExtensionFromLocal()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var sqlite = builder.AddSqlite("sqlite")
+            .WithLocalExtension("FTS5", "/path/to/extension");
+
+        Assert.Single(sqlite.Resource.Extensions, static e => e.Extension == "FTS5" && e.PackageName is null && !e.IsNuGetPackage && e.ExtensionFolder == "/path/to/extension");
     }
 
     [Fact]
@@ -150,8 +160,8 @@ public class AddSqliteTests
     {
         var builder = DistributedApplication.CreateBuilder();
         var sqlite = builder.AddSqlite("sqlite")
-            .WithExtension("FTS5")
-            .WithExtension("mod_spatialite");
+            .WithNuGetExtension("FTS5")
+            .WithNuGetExtension("mod_spatialite");
 
         var connectionString = await sqlite.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
 

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests.csproj
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests.csproj
@@ -5,7 +5,4 @@
     <ProjectReference Include="../../examples/sqlite/CommunityToolkit.Aspire.Sqlite.AppHost/CommunityToolkit.Aspire.Sqlite.AppHost.csproj" />
     <ProjectReference Include="..\..\src\CommunityToolkit.Aspire.Microsoft.Data.Sqlite\CommunityToolkit.Aspire.Microsoft.Data.Sqlite.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="mod_spatialite" />
-  </ItemGroup>
 </Project>

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests.csproj
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests.csproj
@@ -3,5 +3,9 @@
     <ProjectReference Include="..\..\src\CommunityToolkit.Aspire.Hosting.Sqlite\CommunityToolkit.Aspire.Hosting.Sqlite.csproj" />
     <ProjectReference Include="..\CommunityToolkit.Aspire.Testing\CommunityToolkit.Aspire.Testing.csproj" />
     <ProjectReference Include="../../examples/sqlite/CommunityToolkit.Aspire.Sqlite.AppHost/CommunityToolkit.Aspire.Sqlite.AppHost.csproj" />
+    <ProjectReference Include="..\..\src\CommunityToolkit.Aspire.Microsoft.Data.Sqlite\CommunityToolkit.Aspire.Microsoft.Data.Sqlite.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="mod_spatialite" />
   </ItemGroup>
 </Project>

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/ResourceWithExtensionTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/ResourceWithExtensionTests.cs
@@ -1,0 +1,51 @@
+#pragma warning disable CTASPIRE002
+using Aspire.Hosting;
+using Aspire.Hosting.Utils;
+using CommunityToolkit.Aspire.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace CommunityToolkit.Aspire.Hosting.Sqlite.Tests;
+
+[RequiresWindows(Reason = "The NuGet package being used for the extension is Windows-only.")]
+public class ResourceWithExtensionTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task ResourceCreatedWithExtensionIsAccessible()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var sqlite = builder.AddSqlite("sqlite")
+            .WithNuGetExtension("mod_spatialite");
+
+        await using var app = builder.Build();
+
+        await app.StartAsync();
+
+        var hb = Host.CreateApplicationBuilder();
+
+        hb.AddSqliteConnection(sqlite.Resource.Name);
+
+        using var host = hb.Build();
+
+        await host.StartAsync();
+
+        var connection = host.Services.GetRequiredService<SqliteConnection>();
+
+        var result = await IsExtensionLoadedAsync(connection, "spatialite_version()");
+
+        Assert.NotNull(result);
+        Assert.IsType<string>(result);
+        Assert.Equal("5.1.0", result);
+    }
+
+    private static async Task<object?> IsExtensionLoadedAsync(SqliteConnection connection, string checkFunction)
+    {
+        string checkQuery = $"SELECT {checkFunction}";
+        using var command = connection.CreateCommand();
+        command.CommandText = checkQuery;
+        return await command.ExecuteScalarAsync();
+    }
+}

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/ResourceWithExtensionTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/ResourceWithExtensionTests.cs
@@ -8,16 +8,15 @@ using Xunit.Abstractions;
 
 namespace CommunityToolkit.Aspire.Hosting.Sqlite.Tests;
 
-[RequiresWindows(Reason = "The NuGet package being used for the extension is Windows-only.")]
 public class ResourceWithExtensionTests(ITestOutputHelper testOutputHelper)
 {
-    [Fact]
+    [Fact(Skip = "Skipping until there is a viable NuGet package for sqlite-vec we can use.")]
     public async Task ResourceCreatedWithExtensionIsAccessible()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
         var sqlite = builder.AddSqlite("sqlite")
-            .WithNuGetExtension("mod_spatialite");
+            .WithNuGetExtension("sqlite-vec");
 
         await using var app = builder.Build();
 
@@ -35,11 +34,11 @@ public class ResourceWithExtensionTests(ITestOutputHelper testOutputHelper)
 
         var connection = host.Services.GetRequiredService<SqliteConnection>();
 
-        var result = await IsExtensionLoadedAsync(connection, "spatialite_version()");
+        var result = await IsExtensionLoadedAsync(connection, "vec_version()");
 
         Assert.NotNull(result);
         var version = Assert.IsType<string>(result);
-        Assert.Equal("4.3.0a", version);
+        Assert.Equal("0.1.16", version);
     }
 
     private static async Task<object?> IsExtensionLoadedAsync(SqliteConnection connection, string checkFunction)

--- a/tests/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.Tests/ConfigurationTests.cs
+++ b/tests/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.Tests/ConfigurationTests.cs
@@ -11,4 +11,8 @@ public class ConfigurationTests
     [Fact]
     public void HealthChecksEnabledByDefault() =>
         Assert.False(new SqliteConnectionSettings().DisableHealthChecks);
+
+    [Fact]
+    public void ExtensionsIsEmptyByDefault() =>
+        Assert.Empty(new SqliteConnectionSettings().Extensions);
 }

--- a/tests/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.Tests/SqliteConnectionTests.cs
+++ b/tests/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.Tests/SqliteConnectionTests.cs
@@ -115,4 +115,32 @@ public class SqliteConnectionTests
         Assert.NotNull(client2.ConnectionString);
         Assert.Equal("Data Source=/tmp/sqlite2.db", client2.ConnectionString);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ExtensionsSetViaConnectionString(bool useKeyed)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:sqlite", "Data Source=:memory:;Extensions=[\"mod_spatialite\"]")
+        ]);
+
+        if (useKeyed)
+        {
+            builder.AddKeyedSqliteConnection("sqlite", settings =>
+            {
+                Assert.NotEmpty(settings.Extensions);
+                Assert.Contains("mod_spatialite", settings.Extensions);
+            });
+        }
+        else
+        {
+            builder.AddSqliteConnection("sqlite", settings =>
+            {
+                Assert.NotEmpty(settings.Extensions);
+                Assert.Contains("mod_spatialite", settings.Extensions);
+            });
+        }
+    }
 }

--- a/tests/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.Tests/SqliteConnectionTests.cs
+++ b/tests/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.Tests/SqliteConnectionTests.cs
@@ -32,7 +32,7 @@ public class SqliteConnectionTests
             host.Services.GetRequiredService<SqliteConnection>();
 
         Assert.NotNull(client.ConnectionString);
-        Assert.Equal("Data Source=:memory:", client.ConnectionString);
+        Assert.Equal("data source=:memory:", client.ConnectionString);
     }
 
     [Theory]
@@ -60,7 +60,7 @@ public class SqliteConnectionTests
             host.Services.GetRequiredService<SqliteConnection>();
 
         Assert.NotNull(client.ConnectionString);
-        Assert.Equal("Data Source=:memory:", client.ConnectionString);
+        Assert.Equal("data source=:memory:", client.ConnectionString);
     }
 
     [Theory]
@@ -89,7 +89,7 @@ public class SqliteConnectionTests
             host.Services.GetRequiredService<SqliteConnection>();
 
         Assert.NotNull(client.ConnectionString);
-        Assert.Equal("Data Source=:memory:", client.ConnectionString);
+        Assert.Equal("data source=:memory:", client.ConnectionString);
     }
 
     [Fact]
@@ -110,10 +110,10 @@ public class SqliteConnectionTests
         var client2 = host.Services.GetRequiredKeyedService<SqliteConnection>("sqlite2");
 
         Assert.NotNull(client1.ConnectionString);
-        Assert.Equal("Data Source=/tmp/sqlite1.db", client1.ConnectionString);
+        Assert.Equal("data source=/tmp/sqlite1.db", client1.ConnectionString);
 
         Assert.NotNull(client2.ConnectionString);
-        Assert.Equal("Data Source=/tmp/sqlite2.db", client2.ConnectionString);
+        Assert.Equal("data source=/tmp/sqlite2.db", client2.ConnectionString);
     }
 
     [Theory]

--- a/tests/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.Tests/SqliteConnectionTests.cs
+++ b/tests/CommunityToolkit.Aspire.Microsoft.Data.Sqlite.Tests/SqliteConnectionTests.cs
@@ -123,7 +123,7 @@ public class SqliteConnectionTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("ConnectionStrings:sqlite", "Data Source=:memory:;Extensions=[\"mod_spatialite\"]")
+            new KeyValuePair<string, string?>("ConnectionStrings:sqlite", "Data Source=:memory:;Extensions=[{\"Extension\":\"mod_spatialite\",\"PackageName\":\"mod_spatialite\",\"IsNuGetPackage\":true,\"ExtensionFolder\":null}]")
         ]);
 
         if (useKeyed)
@@ -131,7 +131,7 @@ public class SqliteConnectionTests
             builder.AddKeyedSqliteConnection("sqlite", settings =>
             {
                 Assert.NotEmpty(settings.Extensions);
-                Assert.Contains("mod_spatialite", settings.Extensions);
+                Assert.Single(settings.Extensions, e => e.Extension == "mod_spatialite" && e.PackageName == "mod_spatialite" && e.IsNuGetPackage && e.ExtensionFolder is null);
             });
         }
         else
@@ -139,7 +139,7 @@ public class SqliteConnectionTests
             builder.AddSqliteConnection("sqlite", settings =>
             {
                 Assert.NotEmpty(settings.Extensions);
-                Assert.Contains("mod_spatialite", settings.Extensions);
+                Assert.Single(settings.Extensions, e => e.Extension == "mod_spatialite" && e.PackageName == "mod_spatialite" && e.IsNuGetPackage && e.ExtensionFolder is null);
             });
         }
     }

--- a/tests/CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite.Tests/SqliteConnectionTests.cs
+++ b/tests/CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite.Tests/SqliteConnectionTests.cs
@@ -22,7 +22,7 @@ public class SqliteConnectionTests
         var client = host.Services.GetRequiredService<TestDbContext>();
 
         Assert.NotNull(client.Database.GetConnectionString());
-        Assert.Equal("Data Source=:memory:", client.Database.GetConnectionString());
+        Assert.Equal("data source=:memory:", client.Database.GetConnectionString());
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class SqliteConnectionTests
         var client = host.Services.GetRequiredService<TestDbContext>();
 
         Assert.NotNull(client.Database.GetConnectionString());
-        Assert.Equal("Data Source=:memory:", client.Database.GetConnectionString());
+        Assert.Equal("data source=:memory:", client.Database.GetConnectionString());
     }
 
     [Fact]
@@ -56,6 +56,6 @@ public class SqliteConnectionTests
         var client = host.Services.GetRequiredService<TestDbContext>();
 
         Assert.NotNull(client.Database.GetConnectionString());
-        Assert.Equal("Data Source=:memory:", client.Database.GetConnectionString());
+        Assert.Equal("data source=:memory:", client.Database.GetConnectionString());
     }
 }

--- a/tests/CommunityToolkit.Aspire.Testing/RequiresWindowsAttribute.cs
+++ b/tests/CommunityToolkit.Aspire.Testing/RequiresWindowsAttribute.cs
@@ -1,0 +1,12 @@
+using Xunit.Sdk;
+
+namespace CommunityToolkit.Aspire.Testing;
+
+[TraitDiscoverer("CommunityToolkit.Aspire.Testing.RequiresWindowsDiscoverer", "CommunityToolkit.Aspire.Testing")]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+public class RequiresWindowsAttribute(string? reason = null) : Attribute, ITraitAttribute
+{
+    public string? Reason { get; init; } = reason;
+
+    public static bool IsSupported => OperatingSystem.IsWindows();
+}

--- a/tests/CommunityToolkit.Aspire.Testing/RequiresWindowsDiscoverer.cs
+++ b/tests/CommunityToolkit.Aspire.Testing/RequiresWindowsDiscoverer.cs
@@ -1,0 +1,15 @@
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace CommunityToolkit.Aspire.Testing;
+
+public class RequiresWindowsDiscoverer : ITraitDiscoverer
+{
+    public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+    {
+        if (!RequiresWindowsAttribute.IsSupported)
+        {
+            yield return new KeyValuePair<string, string>("category", "unsupported-platform");
+        }
+    }
+}


### PR DESCRIPTION
Adding the ability to specify SQLite extensions that you want to load on the database. Extensions can be shipped as NuGet packages (https://www.nuget.org/packages/mod_spatialite is an example) or you can specify a path to the extension binary (an absolute path).

This is done in the app host and the info is projected as part of the connection string for the client.

In the client library, it'll read the extensions from the connection string (then delete that value so it is a valid connection string) and load the extensions using the SqliteConnection. Since SQLite needs the extension to be in PATH ([see this doc](https://learn.microsoft.com/dotnet/standard/data/sqlite/extensions)) there is a bit of code to ensure the path for the binary is loaded correctly.

I've added some tests for _observing_ that the extension loads, but it's a hard one to write tests for as you have to have a bunch of different binaries checked into the repo (I'd use mod_spatialite but it only ships Windows binaries in the nuget package). Because if this, I've marked the feature as experimental.

This doesn't support the EF SQLite integration as there's no way I can find using the EF API in which you can add extensions, you have to do it manually when the DbContext is created.