### PR TITLE
Fix CI, Followup #438

### DIFF
--- a/.github/workflows/dotnet-main.yml
+++ b/.github/workflows/dotnet-main.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     env:
       DOTNET_CONFIGURATION: Release
+      DAPR_VERSION: "1.14.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -12,15 +12,12 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [
-            windows-latest,
-            ubuntu-latest,
-            #, macos-latest
-          ]
+        os: [windows-latest, ubuntu-latest]
       fail-fast: false
     runs-on: "${{ matrix.os }}"
     env:
       DOTNET_CONFIGURATION: Release
+      DAPR_VERSION: "1.14.1"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds the `DAPR_VERSION` variable to the `dotnet-main` and the `dotnet-release` actions, which we should have added in #438.