### PR TITLE
Aligning OllamaSharp with the Aspire OpenAI + MEAI design

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,7 @@
     <DotNetExtensionsVersion>9.0.0</DotNetExtensionsVersion>
     <OpenTelemetryVersion>1.11.0</OpenTelemetryVersion>
     <TestContainersVersion>4.1.0</TestContainersVersion>
+    <MEAIVersion>9.1.0-preview.1.25064.3</MEAIVersion>
     <IsPackable>false</IsPackable>
     <UsePublicApiAnalyzers>true</UsePublicApiAnalyzers>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="$(MEAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(DotNetExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(DotNetExtensionsVersion)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />

--- a/examples/ollama/CommunityToolkit.Aspire.Hosting.Ollama.Web/Program.cs
+++ b/examples/ollama/CommunityToolkit.Aspire.Hosting.Ollama.Web/Program.cs
@@ -12,8 +12,8 @@ builder.Services.AddRazorComponents()
 
 builder.Services.AddOutputCache();
 
-builder.AddKeyedOllamaSharpChatClient(ServiceKeys.Phi3);
-builder.AddKeyedOllamaSharpChatClient(ServiceKeys.Llama);
+builder.AddOllamaApiClient(ServiceKeys.Phi3).AddChatClient();
+builder.AddOllamaApiClient(ServiceKeys.Llama).AddChatClient();
 
 var app = builder.Build();
 

--- a/src/CommunityToolkit.Aspire.OllamaSharp/AspireOllamaApiClientBuilder.cs
+++ b/src/CommunityToolkit.Aspire.OllamaSharp/AspireOllamaApiClientBuilder.cs
@@ -1,0 +1,27 @@
+using OllamaSharp;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Builder class for configuring and creating an instance of AspireOllamaApiClient.
+/// </summary>
+/// <param name="hostBuilder">The <see cref="IHostApplicationBuilder"/> with which services are being registered.</param>
+/// <param name="serviceKey">The service key used to register the <see cref="OllamaApiClient"/> service, if any.</param>
+/// <param name="disableTracing">A flag to indicate whether tracing should be disabled.</param>
+public class AspireOllamaApiClientBuilder(IHostApplicationBuilder hostBuilder, string serviceKey, bool disableTracing)
+{
+    /// <summary>
+    /// The host application builder used to configure the application.
+    /// </summary>
+    public IHostApplicationBuilder HostBuilder { get; } = hostBuilder;
+
+    /// <summary>
+    /// Gets the service key used to register the <see cref="OllamaApiClient"/> service, if any.
+    /// </summary>
+    public string ServiceKey { get; } = serviceKey;
+
+    /// <summary>
+    /// Gets a flag indicating whether tracing should be disabled.
+    /// </summary>
+    public bool DisableTracing { get; } = disableTracing;
+}

--- a/src/CommunityToolkit.Aspire.OllamaSharp/AspireOllamaChatClientExtensions.cs
+++ b/src/CommunityToolkit.Aspire.OllamaSharp/AspireOllamaChatClientExtensions.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using OllamaSharp;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Extension methos for configuring the <see cref="IChatClient" /> from an <see cref="OllamaApiClient"/> 
+/// </summary>
+public static class AspireOllamaChatClientExtensions
+{
+    /// <summary>
+    /// Registers a singleton <see cref="IChatClient"/> in the services provided by the <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">An <see cref="AspireOllamaApiClientBuilder" />.</param>
+    /// <returns>A <see cref="ChatClientBuilder"/> that can be used to build a pipeline around the inner <see cref="IChatClient"/>.</returns>
+    public static ChatClientBuilder AddChatClient(this AspireOllamaApiClientBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+
+        return builder.HostBuilder.Services.AddChatClient(
+                services => CreateInnerChatClient(services, builder))
+            .UseAspireDefaults();
+    }
+
+    /// <summary>
+    /// Registers a keyed singleton <see cref="IChatClient"/> in the services provided by the <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">An <see cref="AspireOllamaApiClientBuilder" />.</param>
+    /// <returns>A <see cref="ChatClientBuilder"/> that can be used to build a pipeline around the inner <see cref="IChatClient"/>.</returns>
+    public static ChatClientBuilder AddKeyedChatClient(
+        this AspireOllamaApiClientBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        ArgumentException.ThrowIfNullOrEmpty(builder.ServiceKey, nameof(builder.ServiceKey));
+
+        return builder.HostBuilder.Services.AddKeyedChatClient(
+                builder.ServiceKey,
+                services => CreateInnerChatClient(services, builder))
+            .UseAspireDefaults();
+    }
+
+    private static IChatClient CreateInnerChatClient(
+        IServiceProvider services,
+        AspireOllamaApiClientBuilder builder)
+    {
+        var ollamaApiClient = services.GetRequiredKeyedService<IOllamaApiClient>(builder.ServiceKey);
+
+        var result = (IChatClient)ollamaApiClient;
+
+        return builder.DisableTracing ? result : new OpenTelemetryChatClient(result);
+    }
+
+    private static ChatClientBuilder UseAspireDefaults(this ChatClientBuilder builder) =>
+        builder.UseLogging()
+               .UseOpenTelemetry();
+}

--- a/src/CommunityToolkit.Aspire.OllamaSharp/AspireOllamaEmbeddingGeneratorExtensions.cs
+++ b/src/CommunityToolkit.Aspire.OllamaSharp/AspireOllamaEmbeddingGeneratorExtensions.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using OllamaSharp;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Extension methos for configuring the <see cref="IEmbeddingGenerator{TInput, TEmbedding}" /> from an <see cref="OllamaApiClient"/> 
+/// </summary>
+public static class AspireOllamaEmbeddingGeneratorExtensions
+{
+    /// <summary>
+    /// Registers a singleton <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> in the services provided by the <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">An <see cref="AspireOllamaApiClientBuilder" />.</param>
+    /// <returns>A <see cref="EmbeddingGeneratorBuilder{TInput, TEmbedding}"/> that can be used to build a pipeline around the inner <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>.</returns>
+    public static EmbeddingGeneratorBuilder<string, Embedding<float>> AddEmbeddingGenerator(
+        this AspireOllamaApiClientBuilder builder)
+    {
+        return builder.HostBuilder.Services.AddEmbeddingGenerator(
+            services => CreateInnerEmbeddingGenerator(services, builder)).UseAspireDefaults();
+    }
+
+    /// <summary>
+    /// Registers a keyed singleton <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/> in the services provided by the <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">An <see cref="AspireOllamaApiClientBuilder" />.</param>
+    /// <returns>A <see cref="EmbeddingGeneratorBuilder{TInput, TEmbedding}"/> that can be used to build a pipeline around the inner <see cref="IEmbeddingGenerator{TInput, TEmbedding}"/>.</returns>
+    public static EmbeddingGeneratorBuilder<string, Embedding<float>> AddKeyedEmbeddingGenerator(
+        this AspireOllamaApiClientBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        ArgumentException.ThrowIfNullOrEmpty(builder.ServiceKey, nameof(builder.ServiceKey));
+
+        return builder.HostBuilder.Services.AddKeyedEmbeddingGenerator(
+            builder.ServiceKey,
+            services => CreateInnerEmbeddingGenerator(services, builder)).UseAspireDefaults();
+    }
+
+    private static IEmbeddingGenerator<string, Embedding<float>> CreateInnerEmbeddingGenerator(
+        IServiceProvider services,
+        AspireOllamaApiClientBuilder builder)
+    {
+        var ollamaApiClient = services.GetRequiredKeyedService<IOllamaApiClient>(builder.ServiceKey);
+
+        var result = (IEmbeddingGenerator<string, Embedding<float>>)ollamaApiClient;
+
+        return builder.DisableTracing
+            ? result
+            : new OpenTelemetryEmbeddingGenerator<string, Embedding<float>>(result);
+    }
+
+    private static EmbeddingGeneratorBuilder<TKey, TEmbedding> UseAspireDefaults<TKey, TEmbedding>(this EmbeddingGeneratorBuilder<TKey, TEmbedding> builder)
+        where TEmbedding : Embedding =>
+            builder.UseLogging()
+                .UseOpenTelemetry();
+}

--- a/src/CommunityToolkit.Aspire.OllamaSharp/CommunityToolkit.Aspire.OllamaSharp.csproj
+++ b/src/CommunityToolkit.Aspire.OllamaSharp/CommunityToolkit.Aspire.OllamaSharp.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/CommunityToolkit.Aspire.OllamaSharp/OllamaSharpSettings.cs
+++ b/src/CommunityToolkit.Aspire.OllamaSharp/OllamaSharpSettings.cs
@@ -32,4 +32,11 @@ public sealed class OllamaSharpSettings
     /// Gets or sets a integer value that indicates the Ollama health check timeout in milliseconds.
     /// </summary>
     public int? HealthCheckTimeout { get; set; }
+
+    /// <summary>
+    /// Gets or sets a boolean value that indicates whether tracing is disabled or not.
+    /// </summary>
+    /// <remarks>Currently, the OllamaSharp SDK does not support tracing, but this is here for future use.</remarks>
+    internal bool DisableTracing { get; set; }
+
 }

--- a/src/CommunityToolkit.Aspire.OllamaSharp/PublicAPI.Unshipped.txt
+++ b/src/CommunityToolkit.Aspire.OllamaSharp/PublicAPI.Unshipped.txt
@@ -1,2 +1,16 @@
 #nullable enable
-
+Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder
+Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder.AspireOllamaApiClientBuilder(Microsoft.Extensions.Hosting.IHostApplicationBuilder! hostBuilder, string! serviceKey, bool disableTracing) -> void
+Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder.DisableTracing.get -> bool
+Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder.HostBuilder.get -> Microsoft.Extensions.Hosting.IHostApplicationBuilder!
+Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder.ServiceKey.get -> string!
+Microsoft.Extensions.Hosting.AspireOllamaChatClientExtensions
+Microsoft.Extensions.Hosting.AspireOllamaEmbeddingGeneratorExtensions
+static Microsoft.Extensions.Hosting.AspireOllamaChatClientExtensions.AddChatClient(this Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder! builder) -> Microsoft.Extensions.AI.ChatClientBuilder!
+static Microsoft.Extensions.Hosting.AspireOllamaChatClientExtensions.AddKeyedChatClient(this Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder! builder) -> Microsoft.Extensions.AI.ChatClientBuilder!
+static Microsoft.Extensions.Hosting.AspireOllamaEmbeddingGeneratorExtensions.AddEmbeddingGenerator(this Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder! builder) -> Microsoft.Extensions.AI.EmbeddingGeneratorBuilder<string!, Microsoft.Extensions.AI.Embedding<float>!>!
+static Microsoft.Extensions.Hosting.AspireOllamaEmbeddingGeneratorExtensions.AddKeyedEmbeddingGenerator(this Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder! builder) -> Microsoft.Extensions.AI.EmbeddingGeneratorBuilder<string!, Microsoft.Extensions.AI.Embedding<float>!>!
+static Microsoft.Extensions.Hosting.AspireOllamaSharpExtensions.AddKeyedOllamaApiClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<CommunityToolkit.Aspire.OllamaSharp.OllamaSharpSettings!>? configureSettings = null) -> Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder!
+static Microsoft.Extensions.Hosting.AspireOllamaSharpExtensions.AddOllamaApiClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<CommunityToolkit.Aspire.OllamaSharp.OllamaSharpSettings!>? configureSettings = null) -> Microsoft.Extensions.Hosting.AspireOllamaApiClientBuilder!
+*REMOVED*static Microsoft.Extensions.Hosting.AspireOllamaSharpExtensions.AddKeyedOllamaApiClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<CommunityToolkit.Aspire.OllamaSharp.OllamaSharpSettings!>? configureSettings = null) -> void
+*REMOVED*static Microsoft.Extensions.Hosting.AspireOllamaSharpExtensions.AddOllamaApiClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<CommunityToolkit.Aspire.OllamaSharp.OllamaSharpSettings!>? configureSettings = null) -> void

--- a/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/ConformanceTests.cs
+++ b/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/ConformanceTests.cs
@@ -38,11 +38,11 @@ public class ConformanceTests(OllamaContainerFeature ollamaContainerFeature) : C
     {
         if (key is null)
         {
-            builder.AddOllamaSharpChatClient("ollama", configure);
+            builder.AddOllamaApiClient("ollama", configure).AddChatClient();
         }
         else
         {
-            builder.AddKeyedOllamaSharpChatClient(key, configure);
+            builder.AddKeyedOllamaApiClient(key, configure).AddKeyedChatClient();
         }
     }
 

--- a/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/OllamaApiClientTests.cs
+++ b/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/OllamaApiClientTests.cs
@@ -133,18 +133,15 @@ public class OllamaApiClientTests
             new KeyValuePair<string, string?>("ConnectionStrings:Embedding", $"Endpoint={Endpoint};Model=Embedding")
         ]);
 
-        builder.AddOllamaSharpChatClient("Chat");
-        builder.AddOllamaSharpEmbeddingGenerator("Embedding");
+        builder.AddOllamaApiClient("Chat").AddChatClient();
+        builder.AddOllamaApiClient("Embedding").AddEmbeddingGenerator();
         using var host = builder.Build();
 
         var chatClient = host.Services.GetRequiredService<IChatClient>();
         var embeddingGenerator = host.Services.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
 
-        var chatAsOllama = (IOllamaApiClient)chatClient;
-        var embeddingAsOllama = (IOllamaApiClient)embeddingGenerator;
-
-        Assert.Equal("Chat", chatAsOllama.SelectedModel);
-        Assert.Equal("Embedding", embeddingAsOllama.SelectedModel);
+        Assert.Equal("Chat", chatClient.Metadata.ModelId);
+        Assert.Equal("Embedding", embeddingGenerator.Metadata.ModelId);
     }
 
     [Fact]
@@ -156,8 +153,8 @@ public class OllamaApiClientTests
             new KeyValuePair<string, string?>("ConnectionStrings:Embedding", $"Endpoint={Endpoint};Model=Embedding")
         ]);
 
-        builder.AddOllamaSharpChatClient("Chat");
-        builder.AddOllamaSharpEmbeddingGenerator("Embedding");
+        builder.AddOllamaApiClient("Chat").AddChatClient();
+        builder.AddOllamaApiClient("Embedding").AddEmbeddingGenerator();
         using var host = builder.Build();
 
         var ollamaApiClients = host.Services.GetServices<IOllamaApiClient>();

--- a/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/OllamaSharpIChatClientTests.cs
+++ b/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/OllamaSharpIChatClientTests.cs
@@ -20,11 +20,11 @@ public class OllamaSharpIChatClientTests
 
         if (useKeyed)
         {
-            builder.AddKeyedOllamaSharpChatClient("Ollama");
+            builder.AddKeyedOllamaApiClient("Ollama").AddKeyedChatClient();
         }
         else
         {
-            builder.AddOllamaSharpChatClient("Ollama");
+            builder.AddOllamaApiClient("Ollama").AddChatClient();
         }
 
         using var host = builder.Build();
@@ -49,11 +49,11 @@ public class OllamaSharpIChatClientTests
 
         if (useKeyed)
         {
-            builder.AddKeyedOllamaSharpChatClient("Ollama", settings => settings.Endpoint = Endpoint);
+            builder.AddKeyedOllamaApiClient("Ollama", settings => settings.Endpoint = Endpoint).AddKeyedChatClient();
         }
         else
         {
-            builder.AddOllamaSharpChatClient("Ollama", settings => settings.Endpoint = Endpoint);
+            builder.AddOllamaApiClient("Ollama", settings => settings.Endpoint = Endpoint).AddChatClient();
         }
 
         using var host = builder.Build();
@@ -79,11 +79,11 @@ public class OllamaSharpIChatClientTests
 
         if (useKeyed)
         {
-            builder.AddKeyedOllamaSharpChatClient("Ollama");
+            builder.AddKeyedOllamaApiClient("Ollama").AddKeyedChatClient();
         }
         else
         {
-            builder.AddOllamaSharpChatClient("Ollama");
+            builder.AddOllamaApiClient("Ollama").AddChatClient();
         }
 
         using var host = builder.Build();
@@ -106,9 +106,9 @@ public class OllamaSharpIChatClientTests
             new KeyValuePair<string, string?>("ConnectionStrings:Ollama3", "Endpoint=https://localhost:5003/")
         ]);
 
-        builder.AddOllamaSharpChatClient("Ollama");
-        builder.AddKeyedOllamaSharpChatClient("Ollama2");
-        builder.AddKeyedOllamaSharpChatClient("Ollama3");
+        builder.AddOllamaApiClient("Ollama").AddChatClient();
+        builder.AddKeyedOllamaApiClient("Ollama2").AddKeyedChatClient();
+        builder.AddKeyedOllamaApiClient("Ollama3").AddKeyedChatClient();
 
         using var host = builder.Build();
         var client = host.Services.GetRequiredService<IChatClient>();

--- a/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/OllamaSharpIEmbeddingGeneratorTests.cs
+++ b/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/OllamaSharpIEmbeddingGeneratorTests.cs
@@ -20,11 +20,11 @@ public class OllamaSharpIEmbeddingGeneratorTests
 
         if (useKeyed)
         {
-            builder.AddKeyedOllamaSharpEmbeddingGenerator("Ollama");
+            builder.AddKeyedOllamaApiClient("Ollama").AddKeyedEmbeddingGenerator();
         }
         else
         {
-            builder.AddOllamaSharpEmbeddingGenerator("Ollama");
+            builder.AddOllamaApiClient("Ollama").AddEmbeddingGenerator();
         }
 
         using var host = builder.Build();
@@ -49,11 +49,11 @@ public class OllamaSharpIEmbeddingGeneratorTests
 
         if (useKeyed)
         {
-            builder.AddKeyedOllamaSharpEmbeddingGenerator("Ollama", settings => settings.Endpoint = Endpoint);
+            builder.AddKeyedOllamaApiClient("Ollama", settings => settings.Endpoint = Endpoint).AddKeyedEmbeddingGenerator(); ;
         }
         else
         {
-            builder.AddOllamaSharpEmbeddingGenerator("Ollama", settings => settings.Endpoint = Endpoint);
+            builder.AddOllamaApiClient("Ollama", settings => settings.Endpoint = Endpoint).AddEmbeddingGenerator(); ;
         }
 
         using var host = builder.Build();
@@ -79,11 +79,11 @@ public class OllamaSharpIEmbeddingGeneratorTests
 
         if (useKeyed)
         {
-            builder.AddKeyedOllamaSharpEmbeddingGenerator("Ollama");
+            builder.AddKeyedOllamaApiClient("Ollama").AddKeyedEmbeddingGenerator();
         }
         else
         {
-            builder.AddOllamaSharpEmbeddingGenerator("Ollama");
+            builder.AddOllamaApiClient("Ollama").AddEmbeddingGenerator();
         }
 
         using var host = builder.Build();
@@ -106,9 +106,9 @@ public class OllamaSharpIEmbeddingGeneratorTests
             new KeyValuePair<string, string?>("ConnectionStrings:Ollama3", "Endpoint=https://localhost:5003/")
         ]);
 
-        builder.AddOllamaSharpEmbeddingGenerator("Ollama");
-        builder.AddKeyedOllamaSharpEmbeddingGenerator("Ollama2");
-        builder.AddKeyedOllamaSharpEmbeddingGenerator("Ollama3");
+        builder.AddOllamaApiClient("Ollama").AddEmbeddingGenerator();
+        builder.AddKeyedOllamaApiClient("Ollama2").AddKeyedEmbeddingGenerator();
+        builder.AddKeyedOllamaApiClient("Ollama3").AddKeyedEmbeddingGenerator();
 
         using var host = builder.Build();
         var client = host.Services.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();


### PR DESCRIPTION
Moving away from our current ways of registering an IChatClient/IEmbeddingGenerator to leverage the builder pattern from MEAI. This allows the consumer to add middleware to the AI pipeline.

Existing methods have been marked as Obsolete.

Set some default middleware with logging and OTEL.

Fixes #461
