### PR TITLE
Fix Mailpit health check status

### DIFF
--- a/examples/mailpit/CommunityToolkit.Aspire.Hosting.MailPit.AppHost/Program.cs
+++ b/examples/mailpit/CommunityToolkit.Aspire.Hosting.MailPit.AppHost/Program.cs
@@ -1,8 +1,10 @@
+using Microsoft.Extensions.Configuration;
 using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var mailPit = builder.AddMailPit("mailpit");
+var httpPort = builder.Configuration.GetValue<int?>("MailPit:HttpPort");
+var mailPit = builder.AddMailPit("mailpit", httpPort: httpPort);
 
 var sendmail = builder.AddProject<CommunityToolkit_Aspire_Hosting_MailPit_SendMailApi>("sendmail")
     .WithReference(mailPit)

--- a/src/CommunityToolkit.Aspire.Hosting.MailPit/MailPitHostingExtension.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.MailPit/MailPitHostingExtension.cs
@@ -37,7 +37,14 @@ public static class MailPitHostingExtension
                 targetPort: MailPitContainerResource.HttpEndpointPort,
                 port: httpPort,
                 name: MailPitContainerResource.HttpEndpointName)
-            .WithHttpHealthCheck("/", httpPort, MailPitContainerResource.HttpEndpointName);
+            .WithHttpHealthCheck(
+                path: "/livez",
+                statusCode: 200,
+                endpointName: MailPitContainerResource.HttpEndpointName)
+            .WithHttpHealthCheck(
+                path: "/readyz",
+                statusCode: 200,
+                endpointName: MailPitContainerResource.HttpEndpointName);
 
         return rb;
     }

--- a/tests/CommunityToolkit.Aspire.Hosting.MailPit.Tests/AppHostHealthChecksTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.MailPit.Tests/AppHostHealthChecksTests.cs
@@ -1,0 +1,40 @@
+using Aspire.Components.Common.Tests;
+using Aspire.Hosting;
+using CommunityToolkit.Aspire.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using System.Security.Cryptography;
+
+namespace CommunityToolkit.Aspire.Hosting.MailPit.Tests;
+
+[RequiresDocker]
+public sealed class AppHostHealthChecksTests(AppHostHealthChecksTests.MailPitAspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_MailPit_AppHost> fixture)
+    : IClassFixture<AppHostHealthChecksTests.MailPitAspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_MailPit_AppHost>>
+{
+    private const string ResourceName = "mailpit";
+
+    [Fact]
+    public async Task ResourceStartsHealthyUsingCustomHttpPort()
+    {
+        await fixture.ResourceNotificationService
+            .WaitForResourceHealthyAsync(ResourceName)
+            .WaitAsync(TimeSpan.FromMinutes(1));
+    }
+
+    public sealed class MailPitAspireIntegrationTestFixture<TEntryPoint>()
+        : AspireIntegrationTestFixture<TEntryPoint> where TEntryPoint : class
+    {
+        protected override void OnBuilderCreated(DistributedApplicationBuilder applicationBuilder)
+        {
+            base.OnBuilderCreated(applicationBuilder);
+            applicationBuilder.Configuration.AddInMemoryCollection([
+                new KeyValuePair<string, string?>("MailPit:HttpPort", $"{GetRandomPort()}"),
+            ]);
+        }
+
+        private static int GetRandomPort()
+        {
+            return RandomNumberGenerator.GetInt32(1024, 65535);
+        }
+    }
+}


### PR DESCRIPTION
**Closes #511**

Replace health-checks added via `/` route, to health checks exposed by MailPit at `/livez` and `/readyz` routes.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Code follows all style conventions
