### PR TITLE
Add optional parameter to use https for ViteApp

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.NodeJS.Extensions/NodeJSHostingExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.NodeJS.Extensions/NodeJSHostingExtensions.cs
@@ -19,9 +19,10 @@ public static class NodeJSHostingExtensions
     /// <param name="name">The name of the Vite app.</param>
     /// <param name="workingDirectory">The working directory of the Vite app. If not specified, it will be set to a path that is a sibling of the AppHost directory using the <paramref name="name"/> as the folder.</param>
     /// <param name="packageManager">The package manager to use. Default is npm.</param>
+    /// <param name="useHttps">When true use HTTPS for the endpoints, otherwise use HTTP.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>This uses the specified package manager (default npm) method internally but sets defaults that would be expected to run a Vite app, such as the command to run the dev server and exposing the HTTP endpoints.</remarks>
-    public static IResourceBuilder<NodeAppResource> AddViteApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string? workingDirectory = null, string packageManager = "npm")
+    public static IResourceBuilder<NodeAppResource> AddViteApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string? workingDirectory = null, string packageManager = "npm", bool useHttps = false)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -36,8 +37,9 @@ public static class NodeJSHostingExtensions
             _ => builder.AddNpmApp(name, wd, "dev")
         };
 
-        return resource.WithHttpEndpoint(env: "PORT")
-                       .WithExternalHttpEndpoints();
+        return useHttps
+            ? resource.WithHttpsEndpoint(env: "PORT").WithExternalHttpEndpoints()
+            : resource.WithHttpEndpoint(env: "PORT").WithExternalHttpEndpoints();
     }
 
     /// <summary>

--- a/src/CommunityToolkit.Aspire.Hosting.NodeJS.Extensions/PublicAPI.Unshipped.txt
+++ b/src/CommunityToolkit.Aspire.Hosting.NodeJS.Extensions/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
-
+static Aspire.Hosting.NodeJSHostingExtensions.AddViteApp(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string? workingDirectory = null, string! packageManager = "npm", bool useHttps = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.NodeAppResource!>!
+*REMOVED*static Aspire.Hosting.NodeJSHostingExtensions.AddViteApp(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string? workingDirectory = null, string! packageManager = "npm") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.NodeAppResource!>!

--- a/tests/CommunityToolkit.Aspire.Hosting.NodeJS.Extensions.Tests/ResourceCreationTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.NodeJS.Extensions.Tests/ResourceCreationTests.cs
@@ -120,6 +120,27 @@ public class ResourceCreationTests
     }
 
     [Fact]
+    public void ViteAppHasExposedHttpsEndpoints()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        builder.AddViteApp("vite", useHttps: true);
+
+        using var app = builder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var resource = appModel.Resources.OfType<NodeAppResource>().SingleOrDefault();
+
+        Assert.NotNull(resource);
+
+        Assert.True(resource.TryGetAnnotationsOfType<EndpointAnnotation>(out var endpoints));
+
+        Assert.Contains(endpoints, e => e.UriScheme == "https");
+    }
+
+
+    [Fact]
     public void ViteAppHasExposedExternalHttpEndpoints()
     {
         var builder = DistributedApplication.CreateBuilder();


### PR DESCRIPTION
**Closes #518**

Just add an useHttps optional parameter to the AddViteApp method.

## PR Checklist

- [x ] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

This PR contains a breaking change as it adds an optional parameter to an existing method.
