### PR TITLE
Use “uvicorn” from .venv if available

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Python.Extensions/UvicornAppHostingExtension.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Python.Extensions/UvicornAppHostingExtension.cs
@@ -50,7 +50,8 @@ public static class UvicornAppHostingExtension
             : Path.Join(projectDirectory, virtualEnvironmentPath));
 
         var instrumentationExecutable = virtualEnvironment.GetExecutable("opentelemetry-instrument");
-        var projectExecutable = instrumentationExecutable ?? "uvicorn";
+        var uvicornExecutable = virtualEnvironment.GetExecutable("uvicorn") ?? "uvicorn";
+        var projectExecutable = instrumentationExecutable ?? uvicornExecutable;
 
         var projectResource = new UvicornAppResource(name, projectExecutable, projectDirectory);
 


### PR DESCRIPTION
When adding a Python resource using `AddUvicornApp` and using `uvicorn`, use `uvicorn` from the virtual environment if available, before choosing `uvicorn` from the current active python env.

This is particularly important when running multiple python resources, each with a potentially different version of uvicorn, each stored in separate environments under the resource.

Closes #545

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

This might be considered a breaking change for local development when running python resources off the host python env, without activating the resource venv. Worth evaluating, but the previous implementation seems to depend on some lucky factors, like python resources aligned on the same version and the venv being activated before launching Aspire AppHost.