### PR TITLE
Removing .WithOtlpExporter from Ollama container setup

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaResourceBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaResourceBuilderExtensions.cs
@@ -68,7 +68,6 @@ public static partial class OllamaResourceBuilderExtensions
         return builder.AddResource(resource)
           .WithAnnotation(new ContainerImageAnnotation { Image = OllamaContainerImageTags.Image, Tag = OllamaContainerImageTags.Tag, Registry = OllamaContainerImageTags.Registry })
           .WithHttpEndpoint(port: port, targetPort: 11434, name: OllamaResource.OllamaEndpointName)
-          .WithOtlpExporter()
           .WithHttpHealthCheck("/")
           .ExcludeFromManifest();
     }


### PR DESCRIPTION
We don't need it, since we have no OTEL stuff in the Ollama container, and having it triggers https://github.com/dotnet/aspire/issues/6889

Fixing #559
