### PR TITLE
Remove implicit `WaitFor` in `WithDbGate`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,5 +101,6 @@
 
   <ItemGroup Label=".NET 9 Overrides" Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Update="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions/MongoDBBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions/MongoDBBuilderExtensions.cs
@@ -42,8 +42,7 @@ public static class MongoDBBuilderExtensions
         var dbGateBuilder = DbGateBuilderExtensions.AddDbGate(builder.ApplicationBuilder, containerName);
 
         dbGateBuilder
-            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder))
-            .WaitFor(builder);
+            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder));
 
         configureContainer?.Invoke(dbGateBuilder);
 

--- a/src/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions/PostgresBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions/PostgresBuilderExtensions.cs
@@ -42,8 +42,8 @@ public static class PostgresBuilderExtensions
         var dbGateBuilder = DbGateBuilderExtensions.AddDbGate(builder.ApplicationBuilder, containerName);
 
         dbGateBuilder
-            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder))
-            .WaitFor(builder);
+            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder));
+            
 
         configureContainer?.Invoke(dbGateBuilder);
 

--- a/src/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions/PostgresBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions/PostgresBuilderExtensions.cs
@@ -42,8 +42,7 @@ public static class PostgresBuilderExtensions
         var dbGateBuilder = DbGateBuilderExtensions.AddDbGate(builder.ApplicationBuilder, containerName);
 
         dbGateBuilder
-            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder));
-            
+            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder));            
 
         configureContainer?.Invoke(dbGateBuilder);
 

--- a/src/CommunityToolkit.Aspire.Hosting.Redis.Extensions/RedisBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Redis.Extensions/RedisBuilderExtensions.cs
@@ -41,8 +41,7 @@ public static class RedisBuilderExtensions
         var dbGateBuilder = DbGateBuilderExtensions.AddDbGate(builder.ApplicationBuilder, containerName);
 
         dbGateBuilder
-            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder))
-            .WaitFor(builder);
+            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder));
 
         configureContainer?.Invoke(dbGateBuilder);
 

--- a/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.csproj
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.csproj
@@ -17,6 +17,7 @@
   <!-- Workaround for https://github.com/dotnet/aspire/issues/7779 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options"></PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.csproj
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.csproj
@@ -17,7 +17,7 @@
   <!-- Workaround for https://github.com/dotnet/aspire/issues/7779 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options"></PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/SqlServerBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/SqlServerBuilderExtensions.cs
@@ -42,8 +42,7 @@ public static class SqlServerBuilderExtensions
         var dbGateBuilder = DbGateBuilderExtensions.AddDbGate(builder.ApplicationBuilder, containerName);
 
         dbGateBuilder
-            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder))
-            .WaitFor(builder);
+            .WithEnvironment(context => ConfigureDbGateContainer(context, builder.ApplicationBuilder));
 
         configureContainer?.Invoke(dbGateBuilder);
 


### PR DESCRIPTION
Let users explicitly use `WaitFor`.