### PR TITLE
Removed UsePublicApiAnalyzers property

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -7,6 +7,7 @@ on:
       - "src/**"
       - "examples/**"
       - "tests/**"
+      - "tests-app-hosts/**"
       - Directory.Build.props
       - Directory.Build.targets
       - Directory.Packages.props

--- a/tests-app-hosts/Directory.Build.props
+++ b/tests-app-hosts/Directory.Build.props
@@ -1,8 +1,3 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
-
-  <PropertyGroup>
-    <UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
This pull request removes an unused property group from the `tests-app-hosts/Directory.Build.props` file to clean up the project configuration.

There is no need for this property because we removed this analyzer earlier.