### PR TITLE
Do not run `Generate API Diffs` workflow on forks

### DIFF
--- a/.github/workflows/generate-api-diffs.yml
+++ b/.github/workflows/generate-api-diffs.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   generate-and-pr:
     runs-on: ubuntu-latest
+    if: github.repository == 'CommunityToolkit/Aspire'    
     steps:
       - uses: actions/checkout@v4
     


### PR DESCRIPTION
Fixes #653