### PR TITLE
Ignore dependency updating check for Aspire.Hosting and Aspire.Hosting.*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # Ignore Aspire.Hosting and Aspire.Hosting.*   . We have a separate process for updating them
+      - dependency-name: "Aspire.Hosting"
+      - dependency-name: "Aspire.Hosting.*"
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
Dependbot usually updates these in the wrong way.
For example, see:
https://github.com/CommunityToolkit/Aspire/pull/651/files#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR14

On the other hand, we manually update the Aspire version.