### PR TITLE
Add Adminer support for SqlServer

### DIFF
--- a/examples/adminer/CommunityToolkit.Aspire.Hosting.Adminer.AppHost/CommunityToolkit.Aspire.Hosting.Adminer.AppHost.csproj
+++ b/examples/adminer/CommunityToolkit.Aspire.Hosting.Adminer.AppHost/CommunityToolkit.Aspire.Hosting.Adminer.AppHost.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\CommunityToolkit.Aspire.Hosting.Adminer\CommunityToolkit.Aspire.Hosting.Adminer.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\..\src\CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions\CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\..\..\src\CommunityToolkit.Aspire.Hosting.SqlServer.Extensions\CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.csproj" IsAspireProjectResource="false" />
   </ItemGroup>
 
 </Project>

--- a/examples/adminer/CommunityToolkit.Aspire.Hosting.Adminer.AppHost/Program.cs
+++ b/examples/adminer/CommunityToolkit.Aspire.Hosting.Adminer.AppHost/Program.cs
@@ -10,4 +10,14 @@ var postgres2 = builder.AddPostgres("postgres2")
 postgres2.AddDatabase("db3");
 postgres2.AddDatabase("db4");
 
+var sqlserver1 = builder.AddSqlServer("sqlserver1")
+    .WithAdminer();
+sqlserver1.AddDatabase("db5");
+sqlserver1.AddDatabase("db6");
+
+var sqlserver2 = builder.AddSqlServer("sqlserver2")
+    .WithAdminer();
+sqlserver2.AddDatabase("db7");
+sqlserver2.AddDatabase("db8");
+
 builder.Build().Run();

--- a/examples/sqlserver-ext/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.AppHost/Program.cs
+++ b/examples/sqlserver-ext/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.AppHost/Program.cs
@@ -1,12 +1,14 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlserver1 = builder.AddSqlServer("sqlserver1")
-    .WithDbGate(c => c.WithHostPort(8068));
+    .WithDbGate(c => c.WithHostPort(8068))
+    .WithAdminer(c => c.WithHostPort(8069));
 sqlserver1.AddDatabase("db1");
 sqlserver1.AddDatabase("db2");
 
 var sqlserver2 = builder.AddSqlServer("sqlserver2")
-    .WithDbGate();
+    .WithDbGate()
+    .WithAdminer();
 sqlserver2.AddDatabase("db3");
 sqlserver2.AddDatabase("db4");
 

--- a/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.csproj
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.csproj
@@ -11,9 +11,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CommunityToolkit.Aspire.Hosting.Adminer\CommunityToolkit.Aspire.Hosting.Adminer.csproj" />
     <ProjectReference Include="..\CommunityToolkit.Aspire.Hosting.DbGate\CommunityToolkit.Aspire.Hosting.DbGate.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(SharedDir)\Adminer\AdminerLoginServer.cs" Link="AdminerLoginServer.cs" />
+  </ItemGroup>
+  
   <!-- Workaround for https://github.com/dotnet/aspire/issues/7779 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/README.md
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions/README.md
@@ -2,7 +2,7 @@
 
 This integration contains extensions for the [SqlServer hosting package](https://nuget.org/packages/Aspire.Hosting.SqlServer) for .NET Aspire.
 
-The integration provides support for running [DbGate](https://github.com/dbgate/dbgate) to interact with the SqlServer database.
+The integration provides support for running [DbGate](https://github.com/dbgate/dbgate) and [Adminer](https://github.com/vrana/adminer) to interact with the SqlServer database.
 
 ## Getting Started
 
@@ -20,7 +20,8 @@ Then, in the _Program.cs_ file of `AppHost`, define an SqlServer resource, then 
 
 ```csharp
 var sqlserver = builder.AddSqlServer("sqlserver")
-    .WithDbGate();
+    .WithDbGate()
+    .WithAdminer();
 ```
 
 ## Additional Information

--- a/tests/CommunityToolkit.Aspire.Hosting.Adminer.Tests/AddAdminerTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Adminer.Tests/AddAdminerTests.cs
@@ -146,6 +146,16 @@ public class AddAdminerTests
 
         var postgresResource2 = postgresResourceBuilder2.Resource;
 
+        var sqlserverResourceBuilder1 = builder.AddSqlServer("sqlserver1")
+            .WithAdminer();
+
+        var sqlserverResource1 = sqlserverResourceBuilder1.Resource;
+
+        var sqlserverResourceBuilder2 = builder.AddSqlServer("sqlserver2")
+            .WithAdminer();
+
+        var sqlserverResource2 = sqlserverResourceBuilder2.Resource;
+
         using var app = builder.Build();
 
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -181,6 +191,26 @@ public class AddAdminerTests
                     Password = postgresResource2.PasswordParameter.Value,
                     UserName = postgresResource2.UserNameParameter?.Value ?? "postgres"
                 }
+            },
+            {
+                "sqlserver1",
+                new AdminerLoginServer
+                {
+                    Driver = "mssql",
+                    Server = sqlserverResource1.Name,
+                    Password = sqlserverResource1.PasswordParameter.Value,
+                    UserName = "sa"
+                }
+            },
+            {
+                "sqlserver2",
+                new AdminerLoginServer
+                {
+                    Driver = "mssql",
+                    Server = sqlserverResource2.Name,
+                    Password = sqlserverResource2.PasswordParameter.Value,
+                    UserName = "sa"
+                }
             }
         };
 
@@ -199,6 +229,12 @@ public class AddAdminerTests
             .WithAdminer();
 
         builder.AddPostgres("postgres2")
+            .WithAdminer();
+
+        builder.AddSqlServer("sqlserver1")
+            .WithAdminer();
+
+        builder.AddSqlServer("sqlserver2")
             .WithAdminer();
 
         using var app = builder.Build();

--- a/tests/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.Tests/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.Tests.csproj
+++ b/tests/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.Tests/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.Tests.csproj
@@ -4,4 +4,7 @@
     <ProjectReference Include="..\..\src\CommunityToolkit.Aspire.Hosting.SqlServer.Extensions\CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.csproj" />
     <ProjectReference Include="..\CommunityToolkit.Aspire.Testing\CommunityToolkit.Aspire.Testing.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(SharedDir)\Adminer\AdminerLoginServer.cs" Link="AdminerLoginServer.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

Contributes to #643 

This pull request introduces support for integrating Adminer with SQL Server resources in the `CommunityToolkit.Aspire.Hosting.SqlServer.Extensions` package. The changes include adding a new `WithAdminer` method, updating documentation, and implementing comprehensive tests to validate the functionality.

### New Feature: Adminer Integration

* Added a `WithAdminer` extension method to `SqlServerBuilderExtensions` to enable Adminer as an administration and development platform for SQL Server resources. This includes configuring Adminer containers and managing environment variables for SQL Server instances. [[1]](diffhunk://#diff-95cf3bf5cd992d5b22fc344d8a08f32171c12d4770348dd8c34be781a545ecebR53-R92) [[2]](diffhunk://#diff-95cf3bf5cd992d5b22fc344d8a08f32171c12d4770348dd8c34be781a545ecebR137-R177)
* Updated the `SqlServer.Extensions` project to include a reference to the Adminer project and link the `AdminerLoginServer` shared file.

### Documentation Updates

* Updated the `README.md` file in `SqlServer.Extensions` to include instructions and examples for using Adminer alongside SQL Server resources. [[1]](diffhunk://#diff-00ab3d63dc705ad986651c0201be8b80eb24acccf5e0ad018a420fbbdb8c461fL5-R5) [[2]](diffhunk://#diff-00ab3d63dc705ad986651c0201be8b80eb24acccf5e0ad018a420fbbdb8c461fL23-R24)

### Testing Enhancements

* Added multiple tests in `ResourceCreationTests.cs` to verify the functionality of the `WithAdminer` method, including tests for environment variable annotations, container image tags, and multiple SQL Server resources.
* Extended tests in `AddAdminerTests.cs` to validate Adminer integration with multiple database types. [[1]](diffhunk://#diff-69b241d5bc7e491f7c926c534dce5324fc5b942e8a6d452aa0aec1e74bbccb97R149-R158) [[2]](diffhunk://#diff-69b241d5bc7e491f7c926c534dce5324fc5b942e8a6d452aa0aec1e74bbccb97R194-R213) [[3]](diffhunk://#diff-69b241d5bc7e491f7c926c534dce5324fc5b942e8a6d452aa0aec1e74bbccb97R234-R239)

### Example Updates

* Updated example applications (`Adminer.AppHost` and `SqlServer.Extensions.AppHost`) to demonstrate the use of the `WithAdminer` method for SQL Server resources. [[1]](diffhunk://#diff-bfb4c70fcdd033a6f90d6446a0d179828de72adbef7e87a658b0268370a2b34dR13-R22) [[2]](diffhunk://#diff-7b16c0c5f8f58567fb1d160a5c37a1fe7ef24032cf42ebbec8174c6ac5a93b6eL4-R11)

### Minor Enhancements

* Added `System.Text.Json` references in relevant files for handling JSON serialization of Adminer server configurations. (F56fd49aL11R11, [tests/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.Tests/ResourceCreationTests.csR2](diffhunk://#diff-c52f15d9b2390ce19b2212bcd445403e7792a08f7ea52bb7b897a70f35b1cd91R2))

<!-- Add an overview of the changes here -->

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->