### PR TITLE
fixes #638

### DIFF
--- a/examples/sql-database-projects/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.AppHost/Program.cs
+++ b/examples/sql-database-projects/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.AppHost/Program.cs
@@ -21,4 +21,8 @@ var connection = builder.AddConnectionString("Aspire");
 builder.AddSqlProject<Projects.SdkProject>("existing-db")
         .WithReference(connection);
 
+var delayedProject = builder.AddSqlProject<Projects.SdkProject>("sdk-project-delayed")
+       .WithReference(database)
+       .WithExplicitStart();
+
 builder.Build().Run();

--- a/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectBuilderExtensions.cs
@@ -198,33 +198,68 @@ public static class SqlProjectBuilderExtensions
         {
             builder.ApplicationBuilder.Eventing.Subscribe<ResourceReadyEvent>(target.Resource, async (resourceReady, ct) =>
             {
-                await RunPublish(builder, target, targetDatabaseName, resourceReady.Services, ct);
+                if (builder.Resource.HasAnnotationOfType<ExplicitStartupAnnotation>())
+                {
+                    await MarkNotStarted(builder, resourceReady.Services);
+                }
+                else
+                {
+                    await RunPublish(builder, target, targetDatabaseName, resourceReady.Services, ct);
+                }
             });
         }
-        else 
+        else
         {
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterResourcesCreatedEvent>(async (@event, ct) => {
-                await RunPublish(builder, target, targetDatabaseName, @event.Services, ct);
+            builder.ApplicationBuilder.Eventing.Subscribe<AfterResourcesCreatedEvent>(async (@event, ct) => 
+            {
+                if (builder.Resource.HasAnnotationOfType<ExplicitStartupAnnotation>())
+                {
+                    await MarkNotStarted(builder, @event.Services);
+                }
+                else
+                {
+                    await RunPublish(builder, target, targetDatabaseName, @event.Services, ct);
+                }
             });
         }
 
         builder.WaitFor(target);
 
-        builder.WithCommand("redeploy", "Redeploy", async (context) =>
+        var commandOptions = new CommandOptions
+        {
+            IconName = "ArrowReset",
+            IconVariant = IconVariant.Filled,
+            IsHighlighted = true,
+            Description = "Deploy the SQL Server Database Project to the target database.",
+            UpdateState = (context) =>
+            {
+                if (context.ResourceSnapshot?.State?.Text is string stateText && (stateText == KnownResourceStates.Finished || stateText == KnownResourceStates.NotStarted))
+                {
+                    return ResourceCommandState.Enabled;
+                }
+                else
+                {
+                    return ResourceCommandState.Disabled;
+                }
+            },
+        };           
+
+        builder.WithCommand( "redeploy", "Deploy", async (context) =>
         {
             var service = context.ServiceProvider.GetRequiredService<SqlProjectPublishService>();
             await service.PublishSqlProject(builder.Resource, target.Resource, targetDatabaseName, context.CancellationToken);
             return new ExecuteCommandResult { Success = true };
-        }, new CommandOptions()
-        {
-            Description = "Redeploys the SQL Server Database Project to the target database.",
-            IconName = "ArrowReset",
-            IconVariant = IconVariant.Filled,
-            IsHighlighted = true,
-            UpdateState = (context) => context.ResourceSnapshot?.State?.Text == KnownResourceStates.Finished ? ResourceCommandState.Enabled : ResourceCommandState.Disabled,
-        });
+        }, commandOptions);
 
         return builder;
+    }
+
+    private static async Task MarkNotStarted<TResource>(IResourceBuilder<TResource> builder, IServiceProvider serviceProvider)
+        where TResource : IResourceWithDacpac
+    {
+        var resourceNotificationService = serviceProvider.GetRequiredService<ResourceNotificationService>();
+        await resourceNotificationService.PublishUpdateAsync(builder.Resource,
+            state => state with { State = new ResourceStateSnapshot(KnownResourceStates.NotStarted, KnownResourceStateStyles.Info) });
     }
 
     private static async Task RunPublish<TResource>(IResourceBuilder<TResource> builder, IResourceBuilder<IResourceWithConnectionString> target, string? targetDatabaseName, IServiceProvider serviceProvider, CancellationToken ct) 

--- a/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectBuilderExtensions.cs
@@ -244,7 +244,7 @@ public static class SqlProjectBuilderExtensions
             },
         };           
 
-        builder.WithCommand( "redeploy", "Deploy", async (context) =>
+        builder.WithCommand("deploy", "Deploy", async (context) =>
         {
             var service = context.ServiceProvider.GetRequiredService<SqlProjectPublishService>();
             await service.PublishSqlProject(builder.Resource, target.Resource, targetDatabaseName, context.CancellationToken);

--- a/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/AddSqlProjectTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/AddSqlProjectTests.cs
@@ -110,4 +110,25 @@ public class AddSqlProjectTests
         Assert.Single(app.Services.GetServices<SqlProjectPublishService>());
         Assert.Single(app.Services.GetServices<IDacpacDeployer>());
     }
+
+    [Fact]
+    public void AddSqlProject_WithExplicitStart()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var targetDatabase = appBuilder.AddSqlServer("sql").AddDatabase("test");
+        appBuilder.AddSqlProject<TestProject>("MySqlProject")
+            .WithReference(targetDatabase)
+            .WithExplicitStart();
+
+        // Act
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Assert
+        var sqlProjectResource = Assert.Single(appModel.Resources.OfType<SqlProjectResource>());
+        Assert.Equal("MySqlProject", sqlProjectResource.Name);
+
+        Assert.True(sqlProjectResource.HasAnnotationOfType<ExplicitStartupAnnotation>());
+    }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

**Closes #638**

<!-- Add an overview of the changes here -->

Add explicit start option for SQL projects

Update to check for `ExplicitStartupAnnotation` to determine resource state. Modify the redeploy command and add a test case in `AddSqlProjectTests.cs` to verify the new behavior.


<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->