### PR TITLE
Remove Task.Delay from EventStore tests

### DIFF
--- a/tests/CommunityToolkit.Aspire.Hosting.EventStore.Tests/EventStoreFunctionalTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.EventStore.Tests/EventStoreFunctionalTests.cs
@@ -129,8 +129,6 @@ public class EventStoreFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                //EventStore shutdown can be slightly delayed, so second instance might fail to start when using the same bind mount before shutdown.
-                await Task.Delay(TimeSpan.FromSeconds(5));
                 eventstore2.WithDataBindMount(bindMountPath!);
             }
 


### PR DESCRIPTION
https://github.com/dotnet/aspire/issues/4878 has been resolved, so there is no need for this delay.

Fixes #301 