### PR TITLE
Fix Minio console address - now setting port correctly

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Minio/MinioBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Minio/MinioBuilderExtensions.cs
@@ -39,15 +39,16 @@ public static class MinioBuilderExtensions
         
         var resource = new MinioContainerResource(name, rootUserParameter, rootPasswordParameter);
 
+        const int consoleTargetPort = 9001;
         var builderWithResource = builder
             .AddResource(resource)
             .WithImage(MinioContainerImageTags.Image, MinioContainerImageTags.Tag)
             .WithImageRegistry(MinioContainerImageTags.Registry)
             .WithHttpEndpoint(targetPort: 9000, port: port, name: MinioContainerResource.PrimaryEndpointName)
-            .WithHttpEndpoint(targetPort: 9001, name: MinioContainerResource.ConsoleEndpointName)
+            .WithHttpEndpoint(targetPort: consoleTargetPort, name: MinioContainerResource.ConsoleEndpointName)
             .WithEnvironment(RootUserEnvVarName, resource.RootUser.Value)
             .WithEnvironment(RootPasswordEnvVarName, resource.PasswordParameter.Value)
-            .WithArgs("server", "/data");
+            .WithArgs("server", "/data", "--console-address", $":{consoleTargetPort}");
 
         var endpoint = builderWithResource.Resource.GetEndpoint(MinioContainerResource.PrimaryEndpointName);
         var healthCheckKey = $"{name}_check";

--- a/tests/CommunityToolkit.Aspire.Hosting.Minio.Tests/AppHostTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Minio.Tests/AppHostTests.cs
@@ -23,6 +23,18 @@ public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit
     }
     
     [Fact]
+    public async Task ResourceStartsAndUiRespondsOk()
+    {
+        var resourceName = "minio";
+        await fixture.ResourceNotificationService.WaitForResourceHealthyAsync(resourceName).WaitAsync(TimeSpan.FromMinutes(5));
+        var httpClient = fixture.CreateHttpClient(resourceName, "console");
+
+        var response = await httpClient.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+    
+    [Fact]
     public async Task ApiServiceCreateData()
     {
         const string resourceName = "apiservice";


### PR DESCRIPTION
**Closes #723 **

<!-- Add an overview of the changes here -->

Now Minio resource UI listens to correct port inside the container

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->