### PR TITLE
Add support for DacDeployOption from a publish profile

### DIFF
--- a/examples/sql-database-projects/SdkProject/Database.publish.xml
+++ b/examples/sql-database-projects/SdkProject/Database.publish.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IncludeCompositeObjects>False</IncludeCompositeObjects>
+    <TargetDatabaseName>Database</TargetDatabaseName>
+    <DeployScriptFileName>Database.sql</DeployScriptFileName>
+    <BlockOnPossibleDataLoss>True</BlockOnPossibleDataLoss>
+    <ProfileVersionNumber>1</ProfileVersionNumber>
+  </PropertyGroup>
+</Project>

--- a/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/DacDeployOptionsAnnotation.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/DacDeployOptionsAnnotation.cs
@@ -1,0 +1,9 @@
+﻿namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a metadata annotation that specifies dacpac deployment options.
+/// </summary>
+/// <param name="OptionsPath">path to deployment options xml file</param>
+public record DacDeployOptionsAnnotation(string OptionsPath) : IResourceAnnotation
+{
+}

--- a/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlPackageResource.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlPackageResource.cs
@@ -37,6 +37,19 @@ public sealed class SqlPackageResource<TPackage>(string name) : Resource(name), 
     {
         var options = new DacDeployOptions();
 
+        if (this.TryGetLastAnnotation<DacDeployOptionsAnnotation>(out var optionsAnnotation))
+        {
+            var profile = DacProfile.Load(optionsAnnotation.OptionsPath);
+
+            if (profile == null)
+            {
+                throw new InvalidOperationException($"Unable to load DacProfile from path {optionsAnnotation.OptionsPath} for resource {Name}.");
+            }
+
+            options = profile.DeployOptions;
+            return options;
+        }
+
         if (this.TryGetLastAnnotation<ConfigureDacDeployOptionsAnnotation>(out var configureAnnotation))
         {
             configureAnnotation.ConfigureDeploymentOptions(options);

--- a/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectBuilderExtensions.cs
@@ -143,6 +143,34 @@ public static class SqlProjectBuilderExtensions
     }
 
     /// <summary>
+    /// Adds a path to a publish profile for configuring dacpac deployment options to the <see cref="SqlProjectResource"/>.
+    /// </summary>
+    /// <param name="builder">An <see cref="IResourceBuilder{T}"/> representing the SQL Server Database project.</param>
+    /// <param name="optionsPath">Path to the publish profile xml file</param>
+    /// <returns>An <see cref="IResourceBuilder{T}"/> that can be used to further customize the resource.</returns>
+    public static IResourceBuilder<SqlProjectResource> WithDacDeployOptions(this IResourceBuilder<SqlProjectResource> builder, string optionsPath)
+        => InternalWithDacDeployOptions(builder, optionsPath);
+
+    /// <summary>
+    /// Adds a path to a publish profile for configuring dacpac deployment options to the <see cref="SqlProjectResource"/>.
+    /// </summary>
+    /// <param name="builder">An <see cref="IResourceBuilder{T}"/> representing the SQL Server Database project.</param>
+    /// <param name="optionsPath">Path to the publish profile xml file</param>
+    /// <returns>An <see cref="IResourceBuilder{T}"/> that can be used to further customize the resource.</returns>
+    public static IResourceBuilder<SqlPackageResource<TPackage>> WithDacDeployOptions<TPackage>(this IResourceBuilder<SqlPackageResource<TPackage>> builder, string optionsPath)
+        where TPackage : IPackageMetadata => InternalWithDacDeployOptions(builder, optionsPath);
+
+    internal static IResourceBuilder<TResource> InternalWithDacDeployOptions<TResource>(this IResourceBuilder<TResource> builder, string optionsPath)
+        where TResource : IResourceWithDacpac
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        ArgumentNullException.ThrowIfNull(optionsPath);
+
+        return builder
+            .WithAnnotation(new DacDeployOptionsAnnotation(optionsPath));
+    }
+
+    /// <summary>
     /// Publishes the SQL Server Database project to the target <see cref="SqlServerDatabaseResource"/>.
     /// </summary>
     /// <param name="builder">An <see cref="IResourceBuilder{T}"/> representing the SQL Server Database project to publish.</param>

--- a/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectResource.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectResource.cs
@@ -23,7 +23,7 @@ public sealed class SqlProjectResource(string name) : Resource(name), IResourceW
 
             var project = projectCollection.LoadProject(projectPath);
 
-            // .sqlprojx has a SqlTargetPath property, so try that first
+            // Microsoft.Build.Sql .sqlproj has a SqlTargetPath property, so try that first
             var targetPath = project.GetPropertyValue("SqlTargetPath");
             if (string.IsNullOrWhiteSpace(targetPath))
             {
@@ -44,6 +44,19 @@ public sealed class SqlProjectResource(string name) : Resource(name), IResourceW
     DacDeployOptions IResourceWithDacpac.GetDacpacDeployOptions()
     {
         var options = new DacDeployOptions();
+
+        if (this.TryGetLastAnnotation<DacDeployOptionsAnnotation>(out var optionsAnnotation))
+        {
+            var profile = DacProfile.Load(optionsAnnotation.OptionsPath);
+
+            if (profile == null)
+            {
+                throw new InvalidOperationException($"Unable to load DacProfile from path {optionsAnnotation.OptionsPath} for resource {Name}.");
+            }
+
+            options = profile.DeployOptions;
+            return options;
+        }
 
         if (this.TryGetLastAnnotation<ConfigureDacDeployOptionsAnnotation>(out var configureAnnotation))
         {

--- a/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/AddSqlPackageTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/AddSqlPackageTests.cs
@@ -1,6 +1,5 @@
 using Aspire.Hosting;
 using Microsoft.SqlServer.Dac;
-using System.Configuration;
 
 namespace CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests;
 

--- a/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/AddSqlProjectTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/AddSqlProjectTests.cs
@@ -95,6 +95,55 @@ public class AddSqlProjectTests
     }
 
     [Fact]
+    public void AddSqlProject_WithDeploymentOptions_FromFile_NonExisting()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var optionsPath = "/folder/project.publish.xml";
+
+        appBuilder.AddSqlProject("MySqlProject").WithDacDeployOptions(optionsPath);
+
+        // Act
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Assert
+        var sqlProjectResource = Assert.Single(appModel.Resources.OfType<SqlProjectResource>());
+        Assert.Equal("MySqlProject", sqlProjectResource.Name);
+
+        Assert.True(sqlProjectResource.TryGetLastAnnotation(out DacDeployOptionsAnnotation? dacDeployOptionsAnnotation));
+        Assert.Equal(optionsPath, dacDeployOptionsAnnotation.OptionsPath);
+
+        Assert.Throws<DirectoryNotFoundException>(() => ((IResourceWithDacpac)sqlProjectResource).GetDacpacDeployOptions());
+    }
+
+    [Fact]
+    public void AddSqlProject_WithDeploymentOptions_FromFile()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var optionsPath = "Database.publish.xml";
+
+        appBuilder.AddSqlProject("MySqlProject").WithDacDeployOptions(optionsPath);
+
+        // Act
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Assert
+        var sqlProjectResource = Assert.Single(appModel.Resources.OfType<SqlProjectResource>());
+        Assert.Equal("MySqlProject", sqlProjectResource.Name);
+
+        Assert.True(sqlProjectResource.TryGetLastAnnotation(out DacDeployOptionsAnnotation? dacDeployOptionsAnnotation));
+        Assert.Equal(optionsPath, dacDeployOptionsAnnotation.OptionsPath);
+
+        var options = ((IResourceWithDacpac)sqlProjectResource).GetDacpacDeployOptions();
+        Assert.False(options.BlockOnPossibleDataLoss);
+    }
+
+    [Fact]
     public void WithReference_AddsRequiredServices()
     {
         // Arrange

--- a/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests.csproj
+++ b/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests.csproj
@@ -10,4 +10,10 @@
     <ProjectReference Include="..\..\examples\sql-database-projects\CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.AppHost\CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.AppHost.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Database.publish.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/Database.publish.xml
+++ b/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/Database.publish.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetDatabaseName>Database</TargetDatabaseName>
+    <DeployScriptFileName>Database.sql</DeployScriptFileName>
+    <BlockOnPossibleDataLoss>False</BlockOnPossibleDataLoss>
+    <ProfileVersionNumber>1</ProfileVersionNumber>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
fixes #694

**Closes #694**

Adds a ne WithDacDeployOptions method that takes a path to a publish xml profile

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions
