### PR TITLE
Update MCP Inspector version and extension method parameters

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResource.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResource.cs
@@ -37,7 +37,7 @@ public class McpInspectorResource(string name) : ExecutableResource(name, "npx",
     /// <summary>
     /// Gets the version of the MCP Inspector.
     /// </summary>
-    public const string InspectorVersion = "0.15.0";
+    public const string InspectorVersion = "0.16.2";
 
     private readonly List<McpServerMetadata> _mcpServers = [];
 

--- a/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResourceBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResourceBuilderExtensions.cs
@@ -14,10 +14,11 @@ public static class McpInspectorResourceBuilderExtensions
     /// <param name="name">The name of the MCP Inspector container resource.</param>
     /// <param name="clientPort">The port for the client application. Defaults to 6274.</param>
     /// <param name="serverPort">The port for the server proxy application. Defaults to 6277.</param>
-    public static IResourceBuilder<McpInspectorResource> AddMcpInspector(this IDistributedApplicationBuilder builder, [ResourceName] string name, int clientPort = 6274, int serverPort = 6277)
+    /// <param name="inspectorVersion">The version of the Inspector app to use</param>
+    public static IResourceBuilder<McpInspectorResource> AddMcpInspector(this IDistributedApplicationBuilder builder, [ResourceName] string name, int clientPort = 6274, int serverPort = 6277, string inspectorVersion = McpInspectorResource.InspectorVersion)
     {
         var resource = builder.AddResource(new McpInspectorResource(name))
-            .WithArgs(["-y", $"@modelcontextprotocol/inspector@{McpInspectorResource.InspectorVersion}"])
+            .WithArgs(["-y", $"@modelcontextprotocol/inspector@{inspectorVersion}"])
             .ExcludeFromManifest()
             .WithHttpEndpoint(isProxied: false, port: clientPort, env: "CLIENT_PORT", name: McpInspectorResource.ClientEndpointName)
             .WithHttpEndpoint(isProxied: false, port: serverPort, env: "SERVER_PORT", name: McpInspectorResource.ServerProxyEndpointName)


### PR DESCRIPTION
**Closes #776**

- 🔧 Bump InspectorVersion from 0.15.0 to 0.16.2
- 📦 Add inspectorVersion parameter to AddMcpInspector method allowing for overriding of Inspector version to use, while retaining default for package if not provided

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions