### PR TITLE
Load config file for MCP inspector and update path handling

### DIFF
--- a/examples/mcp-inspector/CommunityToolkit.Aspire.Hosting.McpInspector.McpServer/Program.cs
+++ b/examples/mcp-inspector/CommunityToolkit.Aspire.Hosting.McpInspector.McpServer/Program.cs
@@ -10,7 +10,7 @@ builder.Services
 
 var app = builder.Build();
 
-app.MapMcp();
+app.MapMcp("/mcp");
 
 app.Run();
 

--- a/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResource.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResource.cs
@@ -37,7 +37,7 @@ public class McpInspectorResource(string name) : ExecutableResource(name, "npx",
     /// <summary>
     /// Gets the version of the MCP Inspector.
     /// </summary>
-    public const string InspectorVersion = "0.16.2";
+    public const string InspectorVersion = "0.16.5";
 
     private readonly List<McpServerMetadata> _mcpServers = [];
 
@@ -58,7 +58,7 @@ public class McpInspectorResource(string name) : ExecutableResource(name, "npx",
     /// </summary>
     public ParameterResource ProxyTokenParameter { get; set; } = default!;
 
-    internal void AddMcpServer(IResourceWithEndpoints mcpServer, bool isDefault, McpTransportType transportType)
+    internal void AddMcpServer(IResourceWithEndpoints mcpServer, bool isDefault, McpTransportType transportType, string path)
     {
         if (_mcpServers.Any(s => s.Name == mcpServer.Name))
         {
@@ -68,7 +68,8 @@ public class McpInspectorResource(string name) : ExecutableResource(name, "npx",
         McpServerMetadata item = new(
             mcpServer.Name,
             mcpServer.GetEndpoint("http") ?? throw new InvalidOperationException($"The MCP server {mcpServer.Name} must have a 'http' endpoint defined."),
-            transportType);
+            transportType,
+            path);
 
         _mcpServers.Add(item);
 

--- a/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpServerMetadata.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpServerMetadata.cs
@@ -6,4 +6,5 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="Name">The name of the server resource.</param>
 /// <param name="Endpoint">The endpoint reference for the server resource.</param>
 /// <param name="TransportType">The transport type used by the server resource.</param>
-public record McpServerMetadata(string Name, EndpointReference Endpoint, McpTransportType TransportType);
+/// <param name="Path">The path used for MCP communication.</param>
+public record McpServerMetadata(string Name, EndpointReference Endpoint, McpTransportType TransportType, string Path);

--- a/tests/CommunityToolkit.Aspire.Hosting.McpInspector.Tests/McpInspectorResourceBuilderExtensionsTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.McpInspector.Tests/McpInspectorResourceBuilderExtensionsTests.cs
@@ -64,6 +64,33 @@ public class McpInspectorResourceBuilderExtensionsTests
     }
 
     [Fact]
+    public void WithMcpServerCustomPathAddsServerWithCustomPath()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        // Create a mock MCP server resource
+        var mockServer = appBuilder.AddProject<Projects.CommunityToolkit_Aspire_Hosting_McpInspector_McpServer>("mcpServer");
+
+        // Act
+        var inspector = appBuilder.AddMcpInspector("inspector")
+            .WithMcpServer(mockServer, isDefault: true, path: "/custom/mcp/path");
+
+        using var app = appBuilder.Build();
+
+        // Assert
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var inspectorResource = Assert.Single(appModel.Resources.OfType<McpInspectorResource>());
+        Assert.Equal("inspector", inspectorResource.Name);
+
+        Assert.Single(inspectorResource.McpServers);
+        Assert.NotNull(inspectorResource.DefaultMcpServer);
+        Assert.Equal("mcpServer", inspectorResource.DefaultMcpServer.Name);
+        Assert.Equal("/custom/mcp/path", inspectorResource.DefaultMcpServer.Path);
+    }
+
+    [Fact]
     public void WithMultipleMcpServersAddsAllServersToResource()
     {
         // Arrange


### PR DESCRIPTION
Enable immediate inspection of the MCP inspector by loading the config file. Update the MCP server path handling to allow custom paths for communication.