### PR TITLE
Bump Ollama and Open WebUI tags

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaContainerImageTags.cs
@@ -4,9 +4,9 @@ internal static class OllamaContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "ollama/ollama";
-    public const string Tag = "0.11.3";
+    public const string Tag = "0.11.8";
 
     public const string OpenWebUIRegistry = "ghcr.io";
     public const string OpenWebUIImage = "open-webui/open-webui";
-    public const string OpenWebUITag = "0.6.18";
+    public const string OpenWebUITag = "0.6.26";
 }


### PR DESCRIPTION
Update the version tags for the Ollama and Open WebUI images to the latest releases.