### PR TITLE
[9.5]: Add icons to the otel collector & dev cert export

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector/OpenTelemetryCollectorExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector/OpenTelemetryCollectorExtensions.cs
@@ -40,7 +40,8 @@ public static class OpenTelemetryCollectorExtensions
         var resourceBuilder = builder.AddResource(resource)
             .WithImage(settings.CollectorImage, settings.CollectorTag)
             .WithEnvironment("ASPIRE_ENDPOINT", new HostUrl(url))
-            .WithEnvironment("ASPIRE_API_KEY", builder.Configuration[DashboardOtlpApiKeyVariableName]);
+            .WithEnvironment("ASPIRE_API_KEY", builder.Configuration[DashboardOtlpApiKeyVariableName])
+            .WithIconName("DesktopPulse");
 
         if (settings.EnableGrpcEndpoint)
             resourceBuilder.WithEndpoint(targetPort: 4317, name: OpenTelemetryCollectorResource.GrpcEndpointName, scheme: isHttpsEnabled ? "https" : "http");

--- a/src/Shared/DevCertHostingExtensions.cs
+++ b/src/Shared/DevCertHostingExtensions.cs
@@ -64,6 +64,7 @@ internal static class DevCertHostingExtensions
             exportExecutable = builder.ApplicationBuilder
                 .AddExecutable(exportResourceName, "dotnet", tempDir.FullName)
                 .WithEnvironment("DOTNET_CLI_UI_LANGUAGE", "en") // Ensure consistent output language
+                .WithIconName("Certificate")
                 .WithArgs(context =>
                 {
                     context.Args.Add("dev-certs");


### PR DESCRIPTION
Make use of the `WithIconName` API added in 9.5:

After:
<img width="708" height="561" alt="image" src="https://github.com/user-attachments/assets/2ae489bc-a142-4aa1-8925-cfe061772a4a" />

Before:
<img width="854" height="550" alt="image" src="https://github.com/user-attachments/assets/7bd8e2c1-a546-4ae0-bb64-8c6285f1df85" />

