### PR TITLE
Fix dapr using the wrong component annotations

### DIFF
--- a/examples/dapr/CommunityToolkit.Aspire.Hosting.Dapr.AppHost/Program.cs
+++ b/examples/dapr/CommunityToolkit.Aspire.Hosting.Dapr.AppHost/Program.cs
@@ -7,17 +7,22 @@ var stateStore = builder.AddDaprStateStore("statestore")
     .WaitFor(redis);
 
 var redisHost= redis.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-var redisTargetPort = redis.Resource.PrimaryEndpoint.Property(EndpointProperty.TargetPort);
+var redisPort = redis.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
 
 var pubSub = builder
   .AddDaprPubSub("pubsub")
   .WithMetadata(
     "redisHost",
     ReferenceExpression.Create(
-      $"{redisHost}:{redisTargetPort}"
+      $"{redisHost}:{redisPort}"
     )
   )
   .WaitFor(redis);
+
+if (redis.Resource.PasswordParameter is not null)
+{
+    pubSub.WithMetadata("redisPassword", redis.Resource.PasswordParameter);
+}
 
 builder.AddProject<Projects.CommunityToolkit_Aspire_Hosting_Dapr_ServiceA>("servicea")
        .WithDaprSidecar(sidecar =>

--- a/src/CommunityToolkit.Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -74,7 +74,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook(
 
             var aggregateResourcesPaths = sidecarOptions?.ResourcesPaths.Select(path => NormalizePath(path)).ToHashSet() ?? [];
 
-            var componentReferenceAnnotations = resource.Annotations.OfType<DaprComponentReferenceAnnotation>();
+            var componentReferenceAnnotations = daprSidecar.Annotations.OfType<DaprComponentReferenceAnnotation>();
 
             var secrets = new Dictionary<string, string>();
             var endpointEnvironmentVars = new Dictionary<string, IValueProvider>();


### PR DESCRIPTION
**Closes #878**

This fixes the issue described in #878 by referencing the correct daprSidecar annotations instead of using the main components annotations when looking for `DaprComponentReferenceAnnotation` in `DaprDistributedApplicationLifecycleHook`

It also updates the Dapr example to use the correct redis port and redis password.

## PR Checklist

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [ ] Code follows all style conventions

## Other information
