### PR TITLE
Minio release image tag update

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Minio/MinioContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Minio/MinioContainerImageTags.cs
@@ -6,6 +6,6 @@ internal static class MinioContainerImageTags
     public const string Registry = "docker.io";
     /// <summary>minio/minio</summary>
     public const string Image = "minio/minio";
-    /// <summary>RELEASE.2025-04-22T22-12-26Z</summary>
-    public const string Tag = "RELEASE.2025-04-22T22-12-26Z";
+    /// <summary>RELEASE.2025-09-07T16-13-09Z</summary>
+    public const string Tag = "RELEASE.2025-09-07T16-13-09Z";
 }


### PR DESCRIPTION
MinIO integration is updated to use the latest release/image tag from Dockerhub

Unfortunately it seems to be vulnerable according to [this](https://github.com/minio/minio/issues/21647#issuecomment-3418675115), but it's the best we've got from dockerhub at least for now.