### PR TITLE
Updating KurrentDB.Client to 1.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,7 +92,7 @@
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.10" />
     <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.1" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.1" />
-    <PackageVersion Include="KurrentDB.Client" Version="1.1.0" />
+    <PackageVersion Include="KurrentDB.Client" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <!-- Testing packages -->


### PR DESCRIPTION
**Closes #982**

Updated the KurrentDB.Client package from version 1.1.0 to 1.2.0 – this helped to solve the problem. 

Most likely, the issue was because 1.1.0 and 1.2.0 are simply incompatible since 1.1.0 used System.Linq.Async, while in 1.2.0 it was replaced with System.Linq.AsyncEnumerable.
## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions