### PR TITLE
Work around long path issue with VS on windows.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,4 +17,14 @@
       <PackageVersion>$(PackageVersion)-$(ToolkitPreviewVersion)</PackageVersion>
     </PropertyGroup>
   </Target>
+
+  <!--
+    Workaround to avoid long path length issues that block building in Visual Studio.
+    This needs to go into Directory.Build.targets as it needs to be set after `IntermediateOutputPath` is defined
+
+    See: https://developercommunity.visualstudio.com/t/GeneratedMsBuildEditorConfigeditorconf/11004277
+  -->
+  <PropertyGroup>
+    <GeneratedMSBuildEditorConfigFile>$(IntermediateOutputPath)\GeneratedMSBuildEditorConfig.editorconfig</GeneratedMSBuildEditorConfigFile>
+  </PropertyGroup>  
 </Project>


### PR DESCRIPTION
Without this, if you clone the repo to a path longer than ~25 chars, and try to build the toolkit in VS, it'll fail to build.

See https://developercommunity.visualstudio.com/t/GeneratedMsBuildEditorConfigeditorconf/11004277 .