### PR TITLE
No longer need to disable TLS verification for exporter.

### DIFF
--- a/examples/opentelemetry-collector/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.AppHost/config.yaml
+++ b/examples/opentelemetry-collector/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.AppHost/config.yaml
@@ -24,8 +24,6 @@ exporters:
     endpoint: ${env:ASPIRE_ENDPOINT}
     headers:
       x-otlp-api-key: ${env:ASPIRE_API_KEY}
-    tls:
-      insecure_skip_verify: true
   
 service:
   pipelines:


### PR DESCRIPTION
Aspire 13 automatically injects the dev cert into all containers, so the otel collector contaienr should trust the dev cert without needing any further work.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Contains **NO** breaking changes
- [X] Code follows all style conventions
