### PR TITLE
Update Ollama and OpenWebUI tags to latest versions

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaContainerImageTags.cs
@@ -4,9 +4,9 @@ internal static class OllamaContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "ollama/ollama";
-    public const string Tag = "0.11.8";
+    public const string Tag = "0.13.0";
 
     public const string OpenWebUIRegistry = "ghcr.io";
     public const string OpenWebUIImage = "open-webui/open-webui";
-    public const string OpenWebUITag = "0.6.26";
+    public const string OpenWebUITag = "0.6.38";
 }


### PR DESCRIPTION
**Closes #1002**

This PR bumps the container image tags for both **Ollama** and **Open WebUI** to their latest stable versions.  
These updates are required to ensure compatibility with newly released models such as **embeddinggemma**, **DeepSeek-OCR**, and other Ollama-provided capabilities.

The change is isolated to the `OllamaContainerImageTags` class and does not introduce any breaking changes.

## Overview of Changes

- Updated `ollama/ollama` image tag from the previous version to:
  - `ollama/ollama:0.13.0`
- Updated `open-webui/open-webui` image tag to:
  - `open-webui/open-webui:0.6.38`

These versions include support for improved model serving, additional embedding models, and expanded tooling needed for local inference scenarios.

## PR Checklist

- [x] Changes are isolated to a version bump
- [x] No breaking changes
- [x] XML docs not required (constants only)
- [x] Rebased on latest `main`
- [x] Feature branch used
- [x] No merge commits

## Other Information

The newer Ollama versions add compatibility for updated model families (e.g., Gemma embeddings, DeepSeek OCR models), which allows developers to use these models out-of-the-box when running Aspire-based container setups.
