### PR TITLE
Set Image and Registry Seperately in Otel Collector

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector/OpenTelemetryCollectorExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector/OpenTelemetryCollectorExtensions.cs
@@ -38,7 +38,8 @@ public static class OpenTelemetryCollectorExtensions
 
         var resource = new OpenTelemetryCollectorResource(name);
         var resourceBuilder = builder.AddResource(resource)
-            .WithImage(settings.CollectorImage, settings.CollectorTag)
+            .WithImage(settings.Image, settings.CollectorTag)
+            .WithImageRegistry(settings.Registry)
             .WithEnvironment("ASPIRE_ENDPOINT", new HostUrl(url))
             .WithEnvironment("ASPIRE_API_KEY", builder.Configuration[DashboardOtlpApiKeyVariableName])
             .WithIconName("DesktopPulse");

--- a/tests/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.Tests/ResourceCreationTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.Tests/ResourceCreationTests.cs
@@ -231,9 +231,8 @@ public class ResourceCreationTests(ITestOutputHelper testOutputHelper)
         Assert.True(collectorResource.TryGetLastAnnotation(out ContainerImageAnnotation? imageAnnotations));
         Assert.NotNull(imageAnnotations);
         Assert.Equal("mytag", imageAnnotations.Tag);
-        Assert.Equal("myregistry.io/myorg/mycollector", imageAnnotations.Image);
-        // Registry is likely set to null/empty when the full path is provided as image
-        Assert.Null(imageAnnotations.Registry);
+        Assert.Equal("myorg/mycollector", imageAnnotations.Image);
+        Assert.Equal("myregistry.io", imageAnnotations.Registry);
     }
 
     [Fact]


### PR DESCRIPTION
Rather than fudge the registry into the image name, set the registry property explicitly.

For some context of why this matters to me - my org's build agents have locked down firewalls, and we have to rewrite public registries to internal mirrors - we do this by looking at the Registry property in a `BeforeStart` hook - see more at https://youtu.be/u0iK6Bv5BZ0?si=AtJ_DmYCn1t0Mq5f&t=1124 .


## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [X] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->