### PR TITLE
Comment out unstable DisplayOrder in annotations

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResourceBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResourceBuilderExtensions.cs
@@ -92,7 +92,7 @@ public static class McpInspectorResourceBuilderExtensions
             .WithEnvironment("MCP_AUTO_OPEN_ENABLED", "false")
             .WithUrlForEndpoint(McpInspectorResource.ClientEndpointName, annotation =>
             {
-                annotation.DisplayText = "Client";;
+                annotation.DisplayText = "Client";
                 // DisplayOrder is unstable and will change in a future version of Aspire. See https://github.com/dotnet/aspire/pull/13785
                 // It can be re-added once the API has been fixed.
                 // annotation.DisplayOrder = 2;


### PR DESCRIPTION
This pull request makes a minor update to the `AddMcpInspector` extension method in `McpInspectorResourceBuilderExtensions.cs`. The change removes the use of the `DisplayOrder` property for endpoint annotations due to instability in the Aspire API, and adds comments explaining the reasoning and future plans.

Endpoint annotation adjustments:

* Removed assignment to `annotation.DisplayOrder` for both `Client` and `Server Proxy` endpoints, with explanatory comments referencing the instability in Aspire and a related GitHub issue. (`src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResourceBuilderExtensions.cs`, [src/CommunityToolkit.Aspire.Hosting.McpInspector/McpInspectorResourceBuilderExtensions.csL95-R105](diffhunk://#diff-eee9c9d55236ac40a63b4108931d00a1a2d81b0fe27450d2ddaf9ab04ec31cc2L95-R105))Comment out DisplayOrder assignments for stability.
