### PR TITLE
Override `WithOtlpExporter` method for SurrealDB hosting

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
@@ -439,7 +439,7 @@ public static class SurrealDbBuilderExtensions
         LogLevel logLevel
     )
     {
-        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        ArgumentNullException.ThrowIfNull(builder);
 
         string value = logLevel switch
         {
@@ -450,6 +450,24 @@ public static class SurrealDbBuilderExtensions
         };
 
         return builder.WithEnvironment("SURREAL_LOG", value);
+    }
+    
+    /// <summary>
+    /// Injects the appropriate environment variables to allow the resource to enable sending telemetry to the dashboard.
+    /// 1. It sets the OTLP endpoint to the value of the DOTNET_DASHBOARD_OTLP_ENDPOINT_URL environment variable.
+    /// 2. It sets the service name and instance id to the resource name and UID. Values are injected by the orchestrator.
+    /// 3. It sets a small batch schedule delay in development. This reduces the delay that OTLP exporter waits to sends telemetry and makes the dashboard telemetry pages responsive.
+    /// </summary>
+    /// <param name="builder">The resource builder.</param>
+    /// <returns>The <see cref="IResourceBuilder{SurrealDbServerResource}"/>.</returns>
+    public static IResourceBuilder<SurrealDbServerResource> WithOtlpExporter(
+        this IResourceBuilder<SurrealDbServerResource> builder
+    )
+    {
+        builder.WithEnvironment("SURREAL_TELEMETRY_PROVIDER", "otlp");
+        OtlpConfigurationExtensions.WithOtlpExporter(builder);
+        
+        return builder;
     }
 
     /// <summary>

--- a/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AddSurrealServerTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AddSurrealServerTests.cs
@@ -210,4 +210,29 @@ public class AddSurrealServerTests
         Assert.True(hasValue);
         Assert.Equal(expected, value);
     }
+
+    [Fact]
+    public async Task AddSurrealServerContainerWithOtlpExporter()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var surrealServer = appBuilder
+            .AddSurrealServer("surreal")
+            .WithOtlpExporter();
+
+        using var app = appBuilder.Build();
+
+        // Verify that OtlpExporterAnnotation is present (added by WithOtlpExporter)
+        // This annotation marks the resource as an OTEL exporter
+        Assert.True(surrealServer.Resource.HasAnnotationOfType<OtlpExporterAnnotation>());
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        var variables = await surrealServer.Resource.GetEnvironmentVariableValuesAsync();
+#pragma warning restore CS0618 // Type or member is obsolete
+        
+        bool hasValue = variables.TryGetValue("SURREAL_TELEMETRY_PROVIDER", out var value);
+        
+        Assert.True(hasValue);
+        Assert.Equal("otlp", value);
+    }
 }


### PR DESCRIPTION
<!-- 🚨 Please Do Not skip any instructions and information mentioned below as they are all required and essential to evaluate and test the PR. By fulfilling all the required information you will be able to reduce the volume of questions and most likely help merge the PR faster 🚨 -->

<!-- ⚠️ We will not merge the PR to the main repo if your changes are not in a *feature branch* of your forked repository. Create a new branch in your repo, **do not use the `main` branch in your repo**! -->

<!-- ⚠️ **Every PR** needs to have a linked issue and have previously been approved. PRs that don't follow this will be rejected. >

<!-- 👉 It is imperative to resolve ONE ISSUE PER PR and avoid making multiple changes unless the changes interrelate with each other -->

<!-- 📝 Please always keep the "☑️ Allow edits by maintainers" button checked in the Pull Request Template as it increases collaboration with the Toolkit maintainers by permitting commits to your PR branch (only) created from your fork. This can let us quickly make fixes for minor typos or forgotten StyleCop issues during review without needing to wait on you doing extra work. Let us help you help us! 🎉 -->

<!-- Add an overview of the changes here -->
SurrealDB server requires variable `SURREAL_TELEMETRY_PROVIDER` to be set to `otlp` to enable exporters.
This PR overrides `WithOtlpExporter` method to ensures this variable is set.

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
Please note that breaking changes are likely to be rejected within minor release cycles or held until major versions. -->

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->

Can't get the test to work with:

```csharp
var config = await surrealServer.Resource.GetEnvironmentVariablesAsync();

bool hasValue = config.TryGetValue("SURREAL_TELEMETRY_PROVIDER", out var value);

Assert.True(hasValue);
Assert.Equal("otlp", value);
```

Anyway, I found a workaround.