### PR TITLE
RavenDB: Manifest generation support (deployment plugins)

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.RavenDB/RavenDBBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.RavenDB/RavenDBBuilderExtensions.cs
@@ -66,7 +66,7 @@ public static class RavenDBBuilderExtensions
         };
 
         return AddRavenDbInternal(builder, name, serverResource, environmentVariables, serverSettings.Port,
-            serverSettings.TcpPort, serverSettings.ForceTcpSchema);
+            serverSettings.TcpPort, serverSettings.ForceTcpScheme);
     }
 
     /// <summary>
@@ -102,7 +102,7 @@ public static class RavenDBBuilderExtensions
     Dictionary<string, object> environmentVariables,
     int? port,
     int? tcpPort,
-    bool? forceTcpSchema = false)
+    bool? forceTcpScheme = false)
     {
         string? connectionString = null;
         builder.Eventing.Subscribe<ConnectionStringAvailableEvent>(serverResource, async (_, ct) =>
@@ -122,13 +122,13 @@ public static class RavenDBBuilderExtensions
                 certificate: serverResource.ClientCertificate);
 
         var effectiveTcpPort = tcpPort ?? 38888;
-        var useTcpSchema = forceTcpSchema ?? false;
+        var useTcpScheme = forceTcpScheme ?? false;
         
         return builder.AddResource(serverResource)
             .WithEndpoint(
                 port: port,
                 targetPort: serverResource.IsSecured ? 443 : 8080,
-                scheme: useTcpSchema? "tcp" : serverResource.PrimaryEndpointName,
+                scheme: useTcpScheme? "tcp" : serverResource.PrimaryEndpointName,
                 name: serverResource.PrimaryEndpointName,
                 isProxied: false)
             .WithEndpoint(

--- a/src/CommunityToolkit.Aspire.Hosting.RavenDB/RavenDBServerSettings.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.RavenDB/RavenDBServerSettings.cs
@@ -40,7 +40,7 @@ public class RavenDBServerSettings
     /// Advanced/debug optional parameter that forces the TCP scheme for the RavenDB server URL.
     /// Useful for deployment scenarios with constrained http(s):// schema usage (e.g., only port 80 can use http)
     /// </summary>
-    public bool? ForceTcpSchema { get; set; }
+    public bool? ForceTcpScheme { get; set; }
 
     /// <summary>
     /// Protected constructor to allow inheritance but prevent direct instantiation.


### PR DESCRIPTION
**Closes #1134**

Additional check before reaching to the TcpEndpoint details, and a new flag that forces tcp schema on primary RavenDB endpoint allolwing to deploy to ACA, and similar environments that need generated app manifest. Related [ticket](https://issues.hibernatingrhinos.com/issue/RavenDB-25559/Aspire-Getting-RavenDB-to-deploy-in-ACA) on RavenDB bugtracker.
## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions
