### PR TITLE
Allow specifying a custom sidecar resource name via DaprSidecarOptions

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -210,7 +210,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook(
                         ModelNamedArg("--unix-domain-socket", sidecarOptions?.UnixDomainSocket),
                         PostOptionsArgs(Args(sidecarOptions?.Command)));
 
-            var daprCliResourceName = $"{daprSidecar.Name}-cli";
+            var daprCliResourceName = sidecarOptions?.SidecarName ?? $"{daprSidecar.Name}-cli";
             var daprCli = new ExecutableResource(daprCliResourceName, fileName, appHostDirectory);
 
             // Propagate WaitAnnotations from the original resource to the Dapr CLI executable

--- a/src/CommunityToolkit.Aspire.Hosting.Dapr/DaprPolyglotOptions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Dapr/DaprPolyglotOptions.cs
@@ -56,6 +56,7 @@ internal sealed record DaprSidecarExportOptions
     public string? RuntimePath { get; init; }
     public string? SchedulerHostAddress { get; init; }
     public string? UnixDomainSocket { get; init; }
+    public string? SidecarName { get; init; }
 
     public DaprSidecarOptions ToDaprSidecarOptions()
     {
@@ -93,7 +94,8 @@ internal sealed record DaprSidecarExportOptions
             RunFile = RunFile,
             RuntimePath = RuntimePath,
             SchedulerHostAddress = SchedulerHostAddress,
-            UnixDomainSocket = UnixDomainSocket
+            UnixDomainSocket = UnixDomainSocket,
+            SidecarName = SidecarName,
         };
 #pragma warning restore CS0618
     }

--- a/src/CommunityToolkit.Aspire.Hosting.Dapr/DaprSidecarOptions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Dapr/DaprSidecarOptions.cs
@@ -241,4 +241,13 @@ public sealed record DaprSidecarOptions
     /// If specified, the Dapr sidecar will use Unix Domain Sockets for API calls.
     /// </remarks>
     public string? UnixDomainSocket { get; init; }
+
+
+    /// <summary>
+    /// Gets or sets the name of the Dapr sidecar.
+    /// </summary>
+    /// <remarks>
+    /// If specified, the Dapr sidecar name will be used.
+    /// </remarks>
+    public string? SidecarName { get; init; }
 }

--- a/src/CommunityToolkit.Aspire.Hosting.Dapr/IDistributedApplicationComponentBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Dapr/IDistributedApplicationComponentBuilderExtensions.cs
@@ -36,7 +36,12 @@ public static class IDistributedApplicationResourceBuilderExtensions
     [AspireExportIgnore(Reason = "Use the exported DTO-based overload instead to avoid ambiguous polyglot wrapper generation.")]
     public static IResourceBuilder<T> WithDaprSidecar<T>(this IResourceBuilder<T> builder, DaprSidecarOptions? options = null) where T : IResource
     {
-        return builder.WithDaprSidecar(
+        var sidecarName = string.IsNullOrWhiteSpace(options?.SidecarName)
+            ? $"{builder.Resource.Name}-dapr"
+            : options.SidecarName;
+
+        return builder.WithDaprSidecarCore(
+            sidecarName,
             sidecarBuilder =>
             {
                 if (options is not null)
@@ -62,10 +67,36 @@ public static class IDistributedApplicationResourceBuilderExtensions
     [AspireExport("configureDaprSidecar", MethodName = "configureDaprSidecar", Description = "Adds a Dapr sidecar to the resource and exposes it for callback configuration")]
     public static IResourceBuilder<T> WithDaprSidecar<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<IDaprSidecarResource>> configureSidecar) where T : IResource
     {
+        return builder.WithDaprSidecarCore($"{builder.Resource.Name}-dapr", configureSidecar);
+    }
+
+    /// <summary>
+    /// Ensures that a Dapr sidecar is started for the resource with a custom sidecar name.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder instance.</param>
+    /// <param name="sidecarName">The Aspire resource name for the Dapr sidecar.</param>
+    /// <param name="configureSidecar">A callback that can be use to configure the Dapr sidecar.</param>
+    /// <returns>The resource builder instance.</returns>
+    public static IResourceBuilder<T> WithDaprSidecar<T>(
+        this IResourceBuilder<T> builder,
+        string sidecarName,
+        Action<IResourceBuilder<IDaprSidecarResource>> configureSidecar) where T : IResource
+    {
+        return builder.WithDaprSidecarCore(
+            string.IsNullOrWhiteSpace(sidecarName) ? $"{builder.Resource.Name}-dapr" : sidecarName,
+            configureSidecar);
+    }
+
+    private static IResourceBuilder<T> WithDaprSidecarCore<T>(
+        this IResourceBuilder<T> builder,
+        string sidecarName,
+        Action<IResourceBuilder<IDaprSidecarResource>> configureSidecar) where T : IResource
+    {
         // Add Dapr is idempotent, so we can call it multiple times.
         builder.ApplicationBuilder.AddDapr();
 
-        var sidecarBuilder = builder.ApplicationBuilder.AddResource(new DaprSidecarResource($"{builder.Resource.Name}-dapr"))
+        var sidecarBuilder = builder.ApplicationBuilder.AddResource(new DaprSidecarResource(sidecarName))
                                                        .WithInitialState(new()
                                                        {
                                                            Properties = [],

--- a/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/DaprTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Dapr.Tests/DaprTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting;
 using Aspire.Hosting.Utils;
 using CommunityToolkit.Aspire.Testing;
+using Microsoft.AspNetCore.Http;
 
 namespace CommunityToolkit.Aspire.Hosting.Dapr.Tests;
 
@@ -164,5 +165,25 @@ public class DaprTests
         Assert.Contains($"--app-channel-address {expectedChannelAddress}", commandline);
         Assert.Contains($"--app-protocol {expectedSchema}", commandline);
         Assert.NotNull(container.Annotations.OfType<DaprSidecarAnnotation>());
+    }
+
+    [Theory]
+    [InlineData("MyName", "MyName")]
+    [InlineData(null, "name-dapr")]
+    public void WithDaprSidecarName(string? sidecarName, string expectedSidecarName)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var containerResource = builder.AddContainer("name", "image");
+
+        containerResource.WithDaprSidecar(new DaprSidecarOptions
+        {
+            SidecarName = sidecarName
+        }); 
+
+        var annotation = Assert.Single(
+            containerResource.Resource.Annotations.OfType<DaprSidecarAnnotation>());
+
+        Assert.Equal(expectedSidecarName, annotation.Sidecar.Name);
     }
 }


### PR DESCRIPTION
**Closes #1264**

Currently, when a Dapr sidecar is added, the naming chain is:
- Sidecar resource: `{resourceName}-dapr`
- CLI executable resource: `{sidecarName}-cli` → which gives `{resourceName}-dapr-cli`

This means the CLI name is derived from the sidecar name, not directly from the parent resource.

This PR adds a `SidecarName` property to `DaprSidecarOptions` so developers can override the sidecar resource name. When set, the CLI resource name also follows (e.g., `my-sidecar` → `my-sidecar-cli`). When null or whitespace, the current defaults are preserved.

Refactored the existing `WithDaprSidecar` overloads to delegate to a shared `WithDaprSidecarCore` private method. Added a new overload accepting an explicit `sidecarName` parameter.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

None.