### PR TITLE
Powershell Integration - System.Security.Cryptography.Xml Vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ examples/perl/**/local/*
 **cpanfile.snapshot
 **/.modules/
 **/*.AppHost.TypeScript/nuget.config
+*.lscache

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -91,6 +91,7 @@
     <PackageVersion Include="SurrealDb.Net" Version="0.9.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.3.1" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.10" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
     <PackageVersion Include="KurrentDB.Client" Version="1.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -91,7 +91,6 @@
     <PackageVersion Include="SurrealDb.Net" Version="0.9.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.3.1" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.10" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
     <PackageVersion Include="KurrentDB.Client" Version="1.2.0" />
@@ -127,6 +126,7 @@
   <ItemGroup Label="System">
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="$(DotNetExtensionsVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
   <ItemGroup Label="Overrides">
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.14" />

--- a/src/CommunityToolkit.Aspire.Hosting.PowerShell/CommunityToolkit.Aspire.Hosting.PowerShell.csproj
+++ b/src/CommunityToolkit.Aspire.Hosting.PowerShell/CommunityToolkit.Aspire.Hosting.PowerShell.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" />
     <PackageReference Include="Microsoft.PowerShell.SDK" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Aspire.Hosting.PowerShell/DistributedApplicationBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.PowerShell/DistributedApplicationBuilderExtensions.cs
@@ -81,7 +81,9 @@ public static class DistributedApplicationBuilderExtensions
             var poolName = res.Name;
             var poolLogger = loggerService.GetLogger(poolName);
 
-            _ = res.StartAsync(sessionState, notificationService, poolLogger, hostLifetime, ct);
+            // Await pool open so the resource isn't marked Running before the RunspacePool exists.
+            // Otherwise dependent scripts that WaitFor(pool) can race and hit a null Parent.Pool.
+            await res.StartAsync(sessionState, notificationService, poolLogger, hostLifetime, ct);
         });
 
         return poolBuilder;

--- a/src/CommunityToolkit.Aspire.Hosting.PowerShell/PowerShellScriptResource.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.PowerShell/PowerShellScriptResource.cs
@@ -126,9 +126,21 @@ namespace CommunityToolkit.Aspire.Hosting.PowerShell
             CancellationToken cancellationToken = default)
         {
             scriptLogger.LogInformation("Starting PowerShell script '{ScriptName}'", Name);
-           
+
             Debug.Assert(scriptLogger is not null);
             _scriptLogger = scriptLogger;
+
+            // Aspire's WaitFor on the parent runspace pool doesn't reliably block here, so poll until
+            // the pool has been created AND opened by the parent resource before binding the PowerShell
+            // instance to it. Without this, _ps.RunspacePool can be null (hangs InvokeAsync) or in
+            // 'Opening' state (throws InvalidRunspacePoolStateException).
+            while ((Parent.Pool is null || Parent.Pool.RunspacePoolStateInfo.State != System.Management.Automation.Runspaces.RunspacePoolState.Opened)
+                && !cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             Debug.Assert(Parent.Pool is not null);
             _ps.RunspacePool = Parent.Pool;


### PR DESCRIPTION
**Closes #1287 **

This change is the minimum required to get the project building again.

I am unclear if this test was flaky before or not as it refused to build with the Cryptography vulnerability.

Versions of the Powershell SDK above 4.10 don't support .NET 8 anymore.

Even the newest Powershell SDK which doesn't support Net 9 anymore only has Cryptography.XML at 10.0.5 which is still pinged with high vuln.  Had to pull it in manually to pin it at 10.0.6 for now.

I will contact Oising to see if that test is just failing for me or if he's broken too.

It might be that the scripts aren't checked in that are to be running in this test: ScriptsExecuteSuccessfully()

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [?] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

I don't think I broke it, but one of the tests is failing after getting the project to build.

## Other information

<!-- Please add any other information that might be helpful to reviewers. -->