### PR TITLE
Use DatabaseName for Keycloak Postgres JDBC URL

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Keycloak.Extensions/KeycloakPostgresExtension.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Keycloak.Extensions/KeycloakPostgresExtension.cs
@@ -17,7 +17,7 @@ public static class KeycloakPostgresExtension
         var pgServer = database.Resource.Parent;
         var ep = pgServer.GetEndpoint("tcp");
 
-        var dbName = database.Resource.Name;
+        var dbName = database.Resource.DatabaseName;
 
         var jdbcUrl = ReferenceExpression.Create(
             $"jdbc:postgresql://{ep.Property(EndpointProperty.Host)}:{ep.Property(EndpointProperty.Port)}/{dbName}");

--- a/tests/CommunityToolkit.Aspire.Hosting.Keycloak.Extensions.Tests/KeycloakWithPostgresIntegrationTest.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Keycloak.Extensions.Tests/KeycloakWithPostgresIntegrationTest.cs
@@ -92,4 +92,52 @@ public class KeycloakWithPostgresIntegrationTest
 
         await app.StopAsync();
     }
+
+    [Fact]
+    public async Task Keycloak_WithPostgres_Env_Is_Applied_And_DbUrl_Is_Valid_With_Custom_DatabaseName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var pg = builder.AddPostgres("pg");
+        var db = pg.AddDatabase("keycloakdb", "Keycloak_db");
+
+        var kc = builder.AddKeycloak("kc")
+            .WithPostgres(db);
+
+        await using var app = await builder.BuildAsync();
+        await app.StartAsync();
+
+        await app.ResourceNotifications.WaitForResourceAsync(pg.Resource.Name, KnownResourceStates.Running)
+            .WaitAsync(TimeSpan.FromMinutes(3));
+        await app.ResourceNotifications.WaitForResourceAsync(kc.Resource.Name, KnownResourceStates.Running)
+            .WaitAsync(TimeSpan.FromMinutes(5));
+
+        await app.ResourceNotifications
+            .WaitForResourceHealthyAsync(pg.Resource.Name)
+            .WaitAsync(TimeSpan.FromMinutes(3));
+
+
+        await app.ResourceNotifications
+            .WaitForResourceHealthyAsync(kc.Resource.Name)
+            .WaitAsync(TimeSpan.FromMinutes(5));
+
+        Assert.True(kc.Resource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var annotations));
+
+        var context = new EnvironmentCallbackContext(new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)));
+
+        foreach (var annotation in annotations)
+        {
+            await annotation.Callback(context);
+        }
+
+        var env = context.EnvironmentVariables;
+
+        Assert.Equal("postgres", env["KC_DB"]);
+        Assert.True(env.TryGetValue("KC_DB_URL", out var v));
+        var exp = Assert.IsType<ReferenceExpression>(v);
+        Assert.StartsWith("jdbc:postgresql://", exp.Format);
+        Assert.EndsWith($"/Keycloak_db", exp.Format);
+
+        await app.StopAsync();
+    }
 }


### PR DESCRIPTION
**Closes #1327 **

Updated KeycloakPostgresExtension to use the database resource's DatabaseName property instead of Name when building the JDBC connection string. This ensures the correct database name is used, especially when the resource name and actual database name differ.

<!-- All details should be in the linked issue. Feel free to call out any outstanding differences here. -->

## PR Checklist

<!-- Please check if your PR fulfills the following requirements, and remove the ones that are not applicable to the current PR -->

- [X] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [X] Based off latest main branch of toolkit
- [X] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [X] Every new API (including internal ones) has full XML docs
- [X] Code follows all style conventions

## Breaking changes (?)

I don't really know if this is considered a breaking change, but i guess existing environments that persists the database somehow (i.e. deployed or persistent volumes) could have their connections broken if the database name is not updated to reflect the change?