### PR TITLE
Auto-rerun transient Docker startup failures in .NET CI

### DIFF
--- a/.github/workflows/auto-rerun-transient-failures.yml
+++ b/.github/workflows/auto-rerun-transient-failures.yml
@@ -1,0 +1,89 @@
+name: Auto rerun transient PR failures
+
+on:
+  workflow_run:
+    workflows:
+      - .NET CI
+    types:
+      - completed
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun-transient-failures:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Rerun jobs that failed while Docker was unavailable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t failed_jobs < <(
+            gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" --paginate \
+              --jq '.jobs[] | select(.conclusion == "failure") | @base64'
+          )
+
+          if [ "${#failed_jobs[@]}" -eq 0 ]; then
+            echo "No failed jobs found in ${RUN_URL}."
+            exit 0
+          fi
+
+          rerun_count=0
+
+          for encoded_job in "${failed_jobs[@]}"; do
+            job_json="$(echo "${encoded_job}" | base64 --decode)"
+            job_id="$(echo "${job_json}" | jq -r '.id')"
+            job_name="$(echo "${job_json}" | jq -r '.name')"
+            should_rerun="false"
+
+            docker_probe_failed="$(
+              echo "${job_json}" | jq -e '
+                any(.steps[]?;
+                  .name == "Verify Docker is running" and .conclusion == "failure"
+                )
+              ' >/dev/null 2>&1 && echo "true" || echo "false"
+            )"
+
+            if [ "${docker_probe_failed}" == "true" ]; then
+              should_rerun="true"
+            fi
+
+            setup_step_failed="$(
+              echo "${job_json}" | jq -e '
+                any(.steps[]?;
+                  .name == "Setup Runtimes, Caching, and Tools" and .conclusion == "failure"
+                )
+              ' >/dev/null 2>&1 && echo "true" || echo "false"
+            )"
+
+            if [ "${should_rerun}" != "true" ] && [ "${setup_step_failed}" == "true" ]; then
+              job_log="$(gh run view "${RUN_ID}" --job "${job_id}" --log --repo "${REPO}")"
+
+              if echo "${job_log}" | grep -Eiq 'failed to bind host port.*address already in use|address already in use.*failed to bind host port'; then
+                should_rerun="true"
+              fi
+            fi
+
+            if [ "${should_rerun}" != "true" ]; then
+              echo "Skipping ${job_name} (${job_id}): failure does not match known transient Docker signatures."
+              continue
+            fi
+
+            echo "Rerunning ${job_name} (${job_id}) due to matched transient Docker failure signature."
+            gh api --method POST "repos/${REPO}/actions/jobs/${job_id}/rerun" >/dev/null
+            rerun_count=$((rerun_count + 1))
+          done
+
+          echo "Automatically reran ${rerun_count} failed job(s) from ${RUN_URL}."

--- a/.github/workflows/auto-rerun-transient-failures.yml
+++ b/.github/workflows/auto-rerun-transient-failures.yml
@@ -69,9 +69,9 @@ jobs:
             )"
 
             if [ "${should_rerun}" != "true" ] && [ "${setup_step_failed}" == "true" ]; then
-              job_log="$(gh run view "${RUN_ID}" --job "${job_id}" --log --repo "${REPO}")"
-
-              if echo "${job_log}" | grep -Eiq 'failed to bind host port.*address already in use|address already in use.*failed to bind host port'; then
+              if ! job_log="$(gh run view "${RUN_ID}" --job "${job_id}" --log --repo "${REPO}")"; then
+                echo "Unable to fetch logs for ${job_name} (${job_id}); skipping transient Docker log check."
+              elif echo "${job_log}" | grep -Eiq 'failed to bind host port.*address already in use|address already in use.*failed to bind host port'; then
                 should_rerun="true"
               fi
             fi

--- a/.github/workflows/auto-rerun-transient-failures.yml
+++ b/.github/workflows/auto-rerun-transient-failures.yml
@@ -76,6 +76,20 @@ jobs:
               fi
             fi
 
+            if [ "${should_rerun}" != "true" ] && [ "${setup_step_failed}" == "true" ]; then
+              matrix_name="$(echo "${job_name}" | sed -E 's|^[^/]+/ ||')"
+              ts_logs_artifact_name="ts-app-host-logs-${matrix_name}"
+              artifact_dir="$(mktemp -d)"
+
+              if gh run download "${RUN_ID}" --repo "${REPO}" --name "${ts_logs_artifact_name}" -D "${artifact_dir}" >/dev/null 2>&1; then
+                if grep -Eriq 'TaskCanceledException: A task was canceled|Failed to extract bundle|Bundle extraction failed|aspire setup --force' "${artifact_dir}"; then
+                  should_rerun="true"
+                fi
+              fi
+
+              rm -rf "${artifact_dir}"
+            fi
+
             if [ "${should_rerun}" != "true" ]; then
               echo "Skipping ${job_name} (${job_id}): failure does not match known transient Docker signatures."
               continue


### PR DESCRIPTION
N/A

Adds an automated recovery path for transient GitHub Actions failures in PR runs where Docker startup is the root cause.

A new workflow listens for completed `.NET CI` runs and selectively reruns only failed jobs when they match known transient Docker signatures:
- `Verify Docker is running` failed
- `Setup Runtimes, Caching, and Tools` failed with `failed to bind host port ... address already in use`

To avoid retry loops and preserve signal for legitimate failures, reruns are limited to the first attempt only (`run_attempt == 1`) and non-matching failures are skipped.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

This change is intentionally narrow so it does not rerun all failed jobs. It only retries jobs with the two Docker-related transient failure patterns observed in recent CI failures.