### PR TITLE
Fix TypeScript AppHost validation restore

### DIFF
--- a/.github/actions/setup-runtimes-caching/action.yml
+++ b/.github/actions/setup-runtimes-caching/action.yml
@@ -24,17 +24,10 @@ runs:
           9.0.x
           10.0.x
 
-    - name: Resolve Aspire version
-      id: aspire-version
-      shell: bash
-      run: |
-        ASPIRE_VERSION="$(dotnet msbuild Directory.Build.props -nologo -v:q -getProperty:AspireVersion)"
-        echo "version=${ASPIRE_VERSION}" >> "$GITHUB_OUTPUT"
-
     - name: Install Aspire CLI
       uses: timheuer/setup-aspire@v0.1.0
       with:
-        version: ${{ steps.aspire-version.outputs.version }}
+        quality: staging
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/setup-runtimes-caching/action.yml
+++ b/.github/actions/setup-runtimes-caching/action.yml
@@ -24,10 +24,17 @@ runs:
           9.0.x
           10.0.x
 
+    - name: Resolve Aspire version
+      id: aspire-version
+      shell: bash
+      run: |
+        ASPIRE_VERSION="$(dotnet msbuild Directory.Build.props -nologo -v:q -getProperty:AspireVersion)"
+        echo "version=${ASPIRE_VERSION}" >> "$GITHUB_OUTPUT"
+
     - name: Install Aspire CLI
       uses: timheuer/setup-aspire@v0.1.0
       with:
-        quality: dev
+        version: ${{ steps.aspire-version.outputs.version }}
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/setup-runtimes-caching/action.yml
+++ b/.github/actions/setup-runtimes-caching/action.yml
@@ -24,10 +24,17 @@ runs:
           9.0.x
           10.0.x
 
+    - name: Resolve Aspire version
+      id: aspire-version
+      shell: bash
+      run: |
+        ASPIRE_VERSION="$(dotnet msbuild Directory.Build.props -nologo -v:q -getProperty:AspireVersion)"
+        echo "version=${ASPIRE_VERSION}" >> "$GITHUB_OUTPUT"
+
     - name: Install Aspire CLI
       uses: timheuer/setup-aspire@v0.1.0
       with:
-        quality: staging
+        version: ${{ steps.aspire-version.outputs.version }}
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/setup-runtimes-caching/action.yml
+++ b/.github/actions/setup-runtimes-caching/action.yml
@@ -30,11 +30,26 @@ runs:
       run: |
         ASPIRE_VERSION="$(dotnet msbuild Directory.Build.props -nologo -v:q -getProperty:AspireVersion)"
         echo "version=${ASPIRE_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "cli-version=${ASPIRE_VERSION%%-*}" >> "$GITHUB_OUTPUT"
 
     - name: Install Aspire CLI
       uses: timheuer/setup-aspire@v0.1.0
       with:
-        version: ${{ steps.aspire-version.outputs.version }}
+        quality: staging
+
+    - name: Verify Aspire CLI version
+      shell: bash
+      env:
+        EXPECTED_ASPIRE_CLI_VERSION: ${{ steps.aspire-version.outputs.cli-version }}
+      run: |
+        INSTALLED_ASPIRE_CLI_VERSION="$(aspire --version)"
+        case "${INSTALLED_ASPIRE_CLI_VERSION}" in
+          "${EXPECTED_ASPIRE_CLI_VERSION}"|"${EXPECTED_ASPIRE_CLI_VERSION}"+*) ;;
+          *)
+            echo "Expected Aspire CLI version ${EXPECTED_ASPIRE_CLI_VERSION}, but found ${INSTALLED_ASPIRE_CLI_VERSION}."
+            exit 1
+            ;;
+        esac
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/eng/testing/validate-typescript-apphost.ps1
+++ b/eng/testing/validate-typescript-apphost.ps1
@@ -4,17 +4,9 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$AppHostPath,
 
-    [Parameter(Mandatory = $true)]
-    [string]$PackageProjectPath,
-
-    [Parameter(Mandatory = $true)]
-    [string]$PackageName,
-
     [string[]]$WaitForResources = @(),
 
     [string[]]$RequiredCommands = @(),
-
-    [string]$PackageVersion = "",
 
     [ValidateSet("healthy", "up", "down")]
     [string]$WaitStatus = "healthy",
@@ -93,79 +85,11 @@ function Invoke-CleanupStep {
     }
 }
 
-function Remove-PathWithRetry {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path,
-
-        [switch]$Recurse
-    )
-
-    if (-not (Test-Path -LiteralPath $Path)) {
-        return
-    }
-
-    $maxAttempts = 6
-    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-        try {
-            if ($Recurse) {
-                Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
-            }
-            else {
-                Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
-            }
-
-            return
-        }
-        catch {
-            if ($attempt -eq $maxAttempts) {
-                throw
-            }
-
-            Start-Sleep -Milliseconds (250 * $attempt)
-        }
-    }
-}
-
 $resolvedAppHostPath = (Resolve-Path $AppHostPath).Path
-$resolvedPackageProjectPath = (Resolve-Path $PackageProjectPath).Path
 $appHostDirectory = Split-Path -Parent $resolvedAppHostPath
-$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\\..")).Path
-$configPath = Join-Path $appHostDirectory "aspire.config.json"
-$nugetConfigPath = Join-Path $appHostDirectory "nuget.config"
-$localSource = Join-Path ([System.IO.Path]::GetTempPath()) ("ct-polyglot-" + [Guid]::NewGuid().ToString("N"))
-$originalConfig = $null
 $appStarted = $false
 $primaryError = $null
 $cleanupFailures = [System.Collections.Generic.List[string]]::new()
-
-if ([string]::IsNullOrWhiteSpace($PackageVersion)) {
-    $versionPrefix = (& dotnet msbuild $resolvedPackageProjectPath -nologo -v:q -getProperty:VersionPrefix).Trim()
-    if ([string]::IsNullOrWhiteSpace($versionPrefix)) {
-        throw "Could not determine the evaluated VersionPrefix for $resolvedPackageProjectPath."
-    }
-
-    $PackageVersion = "$versionPrefix-polyglot.local"
-}
-
-# Discover local CommunityToolkit project references that also need packing
-$localDependencies = @()
-$projRefJson = (& dotnet msbuild $resolvedPackageProjectPath -nologo -v:q -getItem:ProjectReference) | Out-String
-$projRefData = $projRefJson | ConvertFrom-Json
-$projRefs = @($projRefData.Items.ProjectReference)
-foreach ($ref in $projRefs) {
-    if ($ref.Filename -like "CommunityToolkit.*") {
-        $localDependencies += @{
-            Name = $ref.Filename
-            FullPath = $ref.FullPath
-        }
-    }
-}
-
-if ($localDependencies.Count -gt 0) {
-    $depNames = ($localDependencies | ForEach-Object { $_.Name }) -join ", "
-    Write-Host "Discovered local dependencies to pack: $depNames"
-}
 
 if ($WaitForResources.Count -eq 1 -and -not [string]::IsNullOrWhiteSpace($WaitForResources[0])) {
     $splitOptions = [System.StringSplitOptions]::RemoveEmptyEntries -bor [System.StringSplitOptions]::TrimEntries
@@ -205,53 +129,6 @@ foreach ($secret in $Secrets) {
 }
 
 try {
-    $originalConfig = Get-Content -Path $configPath -Raw
-    New-Item -ItemType Directory -Path $localSource -Force | Out-Null
-
-    Invoke-ExternalCommand "dotnet" @(
-        "pack",
-        $resolvedPackageProjectPath,
-        "-c", "Debug",
-        "-p:PackageVersion=$PackageVersion",
-        "-o", $localSource
-    )
-
-    foreach ($dep in $localDependencies) {
-        Invoke-ExternalCommand "dotnet" @(
-            "pack",
-            $dep.FullPath,
-            "-c", "Debug",
-            "-p:PackageVersion=$PackageVersion",
-            "-o", $localSource
-        )
-    }
-
-    $config = $originalConfig | ConvertFrom-Json -AsHashtable
-    if ($null -eq $config["packages"]) {
-        $config["packages"] = [ordered]@{}
-    }
-
-    $config["packages"][$PackageName] = $PackageVersion
-    foreach ($dep in $localDependencies) {
-        $config["packages"][$dep.Name] = $PackageVersion
-    }
-    $config | ConvertTo-Json -Depth 10 | Set-Content -Path $configPath -NoNewline
-
-    @"
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="local-polyglot" value="$localSource" />
-  </packageSources>
-
-  <packageSourceMapping>
-    <packageSource key="local-polyglot">
-      <package pattern="CommunityToolkit.Aspire.*" />
-    </packageSource>
-  </packageSourceMapping>
-</configuration>
-"@ | Set-Content -Path $nugetConfigPath -NoNewline
-
     Push-Location $appHostDirectory
     try {
         Invoke-ExternalCommand "npm" @("ci")
@@ -341,20 +218,6 @@ finally {
                 "--non-interactive"
             )
         }
-    } -Failures $cleanupFailures
-
-    Invoke-CleanupStep -Description "restore Aspire config" -Action {
-        if ($null -ne $originalConfig) {
-            Set-Content -Path $configPath -Value $originalConfig -NoNewline
-        }
-    } -Failures $cleanupFailures
-
-    Invoke-CleanupStep -Description "remove generated nuget.config" -Action {
-        Remove-PathWithRetry -Path $nugetConfigPath
-    } -Failures $cleanupFailures
-
-    Invoke-CleanupStep -Description "remove local package source" -Action {
-        Remove-PathWithRetry -Path $localSource -Recurse
     } -Failures $cleanupFailures
 }
 

--- a/tests/CommunityToolkit.Aspire.Testing/TypeScriptAppHostTest.cs
+++ b/tests/CommunityToolkit.Aspire.Testing/TypeScriptAppHostTest.cs
@@ -47,7 +47,6 @@ public static class TypeScriptAppHostTest
         string repoRoot = Path.GetFullPath(Path.Combine("..", "..", "..", "..", ".."));
         string scriptPath = Path.Combine(repoRoot, "eng", "testing", "validate-typescript-apphost.ps1");
         string appHostPath = Path.Combine(repoRoot, "examples", exampleName, appHostProject, "apphost.mts");
-        string packageProjectPath = Path.Combine(repoRoot, "src", packageName, $"{packageName}.csproj");
         string shell = OperatingSystem.IsWindows() ? "pwsh.exe" : "pwsh";
 
         List<string> arguments =
@@ -55,9 +54,7 @@ public static class TypeScriptAppHostTest
             "-NoLogo",
             "-NoProfile",
             "-File", scriptPath,
-            "-AppHostPath", appHostPath,
-            "-PackageProjectPath", packageProjectPath,
-            "-PackageName", packageName
+            "-AppHostPath", appHostPath
         ];
 
         if (resources.Count > 0)


### PR DESCRIPTION
Targets #1359.\n\nThis updates the TypeScript AppHost validation path to rely on checked-in local project references instead of packing integrations into a temporary NuGet source. CI now installs the Aspire CLI from the staging channel, while deriving the expected CLI version from the repo's AspireVersion and verifying the installed CLI matches that 13.4.0 line.