### PR TITLE
Simplified Aspire name resolution

### DIFF
--- a/.github/agents/client-integration-creator.agent.md
+++ b/.github/agents/client-integration-creator.agent.md
@@ -51,7 +51,7 @@ Example template:
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>A .NET Aspire client integration for XYZ.</Description>
+    <Description>An Aspire client integration for XYZ.</Description>
     <AdditionalPackageTags>xyz client</AdditionalPackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/.github/agents/hosting-integration-creator.agent.md
+++ b/.github/agents/hosting-integration-creator.agent.md
@@ -50,7 +50,7 @@ Here is an example of a basic `csproj` file for a hosting integration, where the
 
   <PropertyGroup>
     <AdditionalPackageTags>hosting bun javascript</AdditionalPackageTags>
-    <Description>A .NET Aspire integration for hosting Bun apps.</Description>
+    <Description>An Aspire integration for hosting Bun apps.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Aspire.Hosting.Java/README.md
+++ b/src/CommunityToolkit.Aspire.Hosting.Java/README.md
@@ -1,6 +1,6 @@
 # CommunityToolkit.Aspire.Hosting.Java
 
-Provides extension methods and resource definitions for the .NET Aspire AppHost to support running Java applications. The integration supports Maven, Gradle, and standalone JAR-based applications.
+Provides extension methods and resource definitions for the Aspire AppHost to support running Java applications. The integration supports Maven, Gradle, and standalone JAR-based applications.
 
 ## Install the package
 

--- a/src/CommunityToolkit.Aspire.Hosting.Perl/README.md
+++ b/src/CommunityToolkit.Aspire.Hosting.Perl/README.md
@@ -1,6 +1,6 @@
 # CommunityToolkit.Aspire.Hosting.Perl library
 
-Provides extensions methods and resource definitions for the .NET Aspire AppHost to support running Perl.
+Provides extensions methods and resource definitions for the Aspire AppHost to support running Perl.
 
 ## Using the Perl Hosting Integration
 

--- a/src/CommunityToolkit.Aspire.Hosting.Zitadel/CommunityToolkit.Aspire.Hosting.Zitadel.csproj
+++ b/src/CommunityToolkit.Aspire.Hosting.Zitadel/CommunityToolkit.Aspire.Hosting.Zitadel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>A .NET Aspire host integration for Zitadel.</Description>
+    <Description>An Aspire host integration for Zitadel.</Description>
     <AdditionalPackageTags>zitadel auth identity oauth2 authenticatioon openid-connect oidc</AdditionalPackageTags>
   </PropertyGroup>
 

--- a/src/CommunityToolkit.Aspire.Hosting.Zitadel/README.md
+++ b/src/CommunityToolkit.Aspire.Hosting.Zitadel/README.md
@@ -1,6 +1,6 @@
 # CommunityToolkit.Aspire.Hosting.Zitadel library
 
-Provides extension methods and resource definitions for a .NET Aspire AppHost to configure Zitadel.
+Provides extension methods and resource definitions for an Aspire AppHost to configure Zitadel.
 
 ## Getting Started
 


### PR DESCRIPTION
Since there is only one Aspire used throughout this codebase, it is unnecessary to reference it using its fully qualified name. The compiler was already able to resolve Aspire unambiguously, making the additional qualification redundant. The longer form was technically correct but unnecessarily verbose. Additional qualification was found to be informationally redundant. The surrounding context already establishes the intended Aspire.