### PR TITLE
Skip Docker check steps on Windows CI runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -97,6 +97,7 @@ jobs:
           docker-registry: ${{ secrets.CUSTOM_CONTAINER_REGISTRY }}
 
       - name: Verify Docker is running
+        if: runner.os == 'Linux'
         run: docker info
 
       - name: Build test project
@@ -126,7 +127,7 @@ jobs:
           CUSTOM_CONTAINER_REGISTRY: ${{ secrets.CUSTOM_CONTAINER_REGISTRY }}
 
       - name: Dump docker info
-        if: always()
+        if: always() && runner.os == 'Linux'
         run: |
           docker container ls --all
           docker container ls --all --format json


### PR DESCRIPTION
**Closes #<ISSUE_NUMBER>**

The CI test matrix runs on both `ubuntu-latest` and `windows-latest`, but the "Verify Docker is running" and "Dump docker info" steps are meaningless on Windows runners because Linux containers are not supported there. Running `docker info` on Windows would either fail or produce misleading output, and the diagnostic dump has no value.

Both steps are now gated with `runner.os == 'Linux'` so they are skipped on Windows runners entirely while the Linux flow is unchanged. The "Dump docker info" step preserves its `always()` behaviour on Linux (runs whether the job passed or failed).

## PR Checklist

- [ ] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [ ] Based off latest main branch of toolkit
- [ ] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

N/A