### PR TITLE
Harden affected test selection for example changes

### DIFF
--- a/eng/testing/select-affected-tests.cs
+++ b/eng/testing/select-affected-tests.cs
@@ -172,6 +172,13 @@ static class App
                     continue;
                 }
 
+                if (TryGetExampleTests(filePath, projectPaths, nodeToTests, out var exampleName, out var impactedExampleTests))
+                {
+                    selected.UnionWith(impactedExampleTests);
+                    reasons.Add($"Selected {impactedExampleTests.Count} tests because {filePath} belongs to example {exampleName}.");
+                    continue;
+                }
+
                 if (filePath.StartsWith("src/", StringComparison.Ordinal) ||
                     filePath.StartsWith("tests/", StringComparison.Ordinal) ||
                     filePath.StartsWith("examples/", StringComparison.Ordinal) ||
@@ -569,6 +576,42 @@ static class App
 
         tests = [];
         return false;
+    }
+
+    private static bool TryGetExampleTests(
+        string filePath,
+        List<string> projectPaths,
+        Dictionary<string, HashSet<string>> nodeToTests,
+        out string exampleName,
+        out HashSet<string> tests)
+    {
+        tests = [];
+        exampleName = string.Empty;
+
+        if (!filePath.StartsWith("examples/", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var segments = filePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 2)
+        {
+            return false;
+        }
+
+        exampleName = segments[1];
+        var examplePrefix = $"examples/{exampleName}/";
+        var exampleProjects = projectPaths.Where(projectPath => projectPath.StartsWith(examplePrefix, StringComparison.Ordinal));
+
+        foreach (var projectPath in exampleProjects)
+        {
+            if (nodeToTests.TryGetValue(projectPath, out var impacted))
+            {
+                tests.UnionWith(impacted);
+            }
+        }
+
+        return tests.Count > 0;
     }
 
     private static Dictionary<string, string> ParseStringConstants(string contents)


### PR DESCRIPTION
**Closes #<ISSUE_NUMBER>**
N/A

This hardens the affected-test selector so non-project files under `examples/**`, such as a new example `.gitignore`, no longer force the entire integration test matrix to run.

The selector now derives the example root from the changed path, gathers the projects under that example, and reuses the existing dependency graph to select only the tests tied to those example projects. It still falls back to the full matrix when an example change cannot be resolved to any affected tests.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

This is intentionally narrow: it only changes the fallback behavior for unmapped `examples/**` files and preserves the existing full-matrix fallback for truly ambiguous inputs.