### PR TITLE
fix: handle multi-line XML comments in `PackageDiffAsync`

### DIFF
--- a/eng/testing/select-affected-tests.cs
+++ b/eng/testing/select-affected-tests.cs
@@ -679,6 +679,7 @@ static class App
 
         var packageIds = new HashSet<string>(StringComparer.Ordinal);
         var uncertain = false;
+        var inComment = false;
 
         foreach (var rawLine in output.Split('\n', StringSplitOptions.TrimEntries))
         {
@@ -698,9 +699,39 @@ static class App
             }
 
             var line = rawLine[1..].Trim();
-            if (string.IsNullOrEmpty(line) || line.StartsWith("<!--", StringComparison.Ordinal))
+            if (string.IsNullOrEmpty(line))
             {
                 continue;
+            }
+
+            // Track multi-line XML comment state so that continuation lines
+            // of a block comment don't incorrectly trigger uncertain = true.
+            if (inComment)
+            {
+                if (line.Contains("-->", StringComparison.Ordinal))
+                {
+                    inComment = false;
+                }
+                continue;
+            }
+
+            var commentStart = line.IndexOf("<!--", StringComparison.Ordinal);
+            if (commentStart >= 0)
+            {
+                // If the comment doesn't close on this line, enter multi-line comment mode.
+                if (line.IndexOf("-->", commentStart + 4, StringComparison.Ordinal) < 0)
+                {
+                    inComment = true;
+                }
+
+                if (commentStart == 0)
+                {
+                    // Entire line is a comment — skip it.
+                    continue;
+                }
+
+                // Content precedes the comment; trim it away before further processing.
+                line = line[..commentStart].Trim();
             }
 
             if (line.Contains("PackageVersion", StringComparison.Ordinal) &&
@@ -710,7 +741,10 @@ static class App
                 continue;
             }
 
-            uncertain = true;
+            if (!string.IsNullOrEmpty(line))
+            {
+                uncertain = true;
+            }
         }
 
         return (packageIds, uncertain);

--- a/eng/testing/select-affected-tests.cs
+++ b/eng/testing/select-affected-tests.cs
@@ -708,11 +708,22 @@ static class App
             // of a block comment don't incorrectly trigger uncertain = true.
             if (inComment)
             {
-                if (line.Contains("-->", StringComparison.Ordinal))
+                var commentEnd = line.IndexOf("-->", StringComparison.Ordinal);
+                if (commentEnd >= 0)
                 {
                     inComment = false;
+
+                    // Process any content after the comment close marker on the same line.
+                    line = line[(commentEnd + 3)..].Trim();
+                    if (string.IsNullOrEmpty(line))
+                    {
+                        continue;
+                    }
                 }
-                continue;
+                else
+                {
+                    continue;
+                }
             }
 
             var commentStart = line.IndexOf("<!--", StringComparison.Ordinal);

--- a/eng/testing/select-affected-tests.cs
+++ b/eng/testing/select-affected-tests.cs
@@ -741,7 +741,7 @@ static class App
                     continue;
                 }
 
-                // Content precedes the comment; trim it away before further processing.
+                // Content precedes the comment; trim off the comment (and anything after it) before further processing.
                 line = line[..commentStart].Trim();
             }
 


### PR DESCRIPTION
## Problem

The `PackageDiffAsync` method in `eng/testing/select-affected-tests.cs` processes `Directory.Packages.props` diffs line-by-line and skips lines starting with `<!--`. However, continuation lines of a multi-line XML comment block don't start with `<!--`:

```xml
<!-- This is a
     multi-line comment -->
```

The second line would cause `uncertain = true`, triggering a full test-matrix run unnecessarily.

## Fix

Added an `inComment` flag that:
1. Is set to `true` when `<!--` is found on a line with no closing `-->` after it
2. Causes all subsequent lines to be skipped until `-->` is found, then resets to `false`
3. Handles the edge case where a comment follows content on the same line (trims the line to before `<!--`)
4. Guards the final `uncertain = true` with `if (!string.IsNullOrEmpty(line))` since the line may have been trimmed to empty