### PR TITLE
fix: suppress SQLitePCLRaw.lib.e_sqlite3 audit warning (GHSA-2m69-gcr7-jv3q)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,5 +52,8 @@
 
   <ItemGroup>
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-4mjw-xr5x-prpc" />
+    <!-- SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11 depends on vulnerable SQLite < 3.50.2 (memory corruption).
+         No patched NuGet version available yet. Suppress until upstream ships a fix. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Adds a NuGetAuditSuppress entry for [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) — a **HIGH severity** vulnerability in SQLitePCLRaw.lib.e_sqlite3.

## Problem

All versions of SQLitePCLRaw.lib.e_sqlite3 (<= 2.1.11, which is the latest) depend on SQLite < 3.50.2, which has a memory corruption vulnerability. Since **no patched NuGet package exists yet**, the NU1903 audit warning fires on every restore for any project that transitively references SQLite.

Combined with `TreatWarningsAsErrors=true` in `Directory.Build.props`, this breaks CI builds for all SQLite-related projects (Hosting.Sqlite, tests, examples, etc.).

## Fix

Added a `NuGetAuditSuppress` entry following the existing pattern (GHSA-4mjw-xr5x-prpc is already suppressed the same way). This is a temporary suppression that should be removed once upstream ships a patched `SQLitePCLRaw` version.

## Impact

- **Only** suppresses the audit warning — no code changes, no dependency changes
- Unblocks CI for all branches/PRs that touch SQLite-related projects
- Follows the repo's existing pattern for handling unpatched transitive vulnerabilities