### PR TITLE
test(SurrealDb): bump VerifySurrealDbResource and WithDataShouldPersistStateBetweenUsages timeouts to 10 minutes

### DIFF
--- a/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/SurrealDbFunctionalTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/SurrealDbFunctionalTests.cs
@@ -36,7 +36,7 @@ public class SurrealDbFunctionalTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task VerifySurrealDbResource()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
         var ct = cts.Token;
         await using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
@@ -74,7 +74,7 @@ public class SurrealDbFunctionalTests(ITestOutputHelper testOutputHelper)
     [InlineData(false)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
         var ct = cts.Token;
 
         string? volumeName = null;


### PR DESCRIPTION
## Why

The post-merge `.NET main` run for #1394 hit a SurrealDB test failure (run [28141532703](https://github.com/CommunityToolkit/Aspire/actions/runs/28141532703), attempt 2): `SurrealDbFunctionalTests.WithDataShouldPersistStateBetweenUsages(useVolume: False)` cancelled at **5m 03s** with the resource already reporting:

```
- Current State: Running
- Current Health: Healthy
- - - - System.OperationCanceledException : The operation was canceled.
```

i.e. the healthy event arrived right as the 5-minute CTS tripped.

## Root cause

`WithDataShouldPersistStateBetweenUsages` runs **two full app lifecycles back to back** (start surreal → wait healthy → write data → stop, then build a new app → start → wait healthy → read data). On a cold runner the first SurrealDB image pull + container start + healthy check eats most of the 5-minute budget, leaving no headroom for the second app. The other slow tests in this file (`VerifyWaitForOnSurrealDbBlocksDependentResources`, `VerifyWaitForOnSurrealDbBlocksDependentResourcesUntilCancellation`) already use `FromMinutes(10)` -- aligning these two with that.

## What changes

Two-line change:

| Test                                              | Before        | After          |
|---------------------------------------------------|---------------|----------------|
| `VerifySurrealDbResource`                         | `FromMinutes(5)`  | `FromMinutes(10)`  |
| `WithDataShouldPersistStateBetweenUsages`         | `FromMinutes(5)`  | `FromMinutes(10)`  |

Leaves the `[Fact(Skip = ...)]` test (`AddDatabaseCreatesDatabaseWithCustomScript`) at 5 minutes since it doesn't run.

Aaron mentioned image caching is supposed to be in place; if it later proves to be working, the test will simply finish well under the new 10-minute ceiling -- this purely raises the upper bound, no behavior change.

cc @aaronpowell