### PR TITLE
Use trusted publishing for dotnet-main NuGet publish

### DIFF
--- a/.github/workflows/dotnet-main.yml
+++ b/.github/workflows/dotnet-main.yml
@@ -106,6 +106,9 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: nuget-beta
+    permissions:
+      id-token: write
+      contents: read
     # Only run publish when the merged PR does NOT contain the skip label.
     # The label name is configurable via the `SKIP_PUBLISH_LABEL` env in the detector job below.
     if: needs.detect-pr-label.outputs.skip_publish != 'true'
@@ -115,8 +118,14 @@ jobs:
         with:
           name: signed-nuget-packages
 
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to NuGet
-        run: dotnet nuget push ./*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_PACKAGE_PUSH_TOKEN }}
+        run: dotnet nuget push ./*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
 
   publish-azure-artifacts:
     needs: [sign, detect-pr-label]


### PR DESCRIPTION
**Closes:** N/A

This updates the beta NuGet publish path in `dotnet-main.yml` to use NuGet trusted publishing instead of the long-lived API key flow. The goal is to align the workflow with nuget.org's OIDC-based authentication model and avoid the authorization failures we are seeing in CI.

The publish job now requests `id-token: write`, logs in with `NuGet/login@v1`, and uses the short-lived `NUGET_API_KEY` output from that step when pushing packages. I also added `--skip-duplicate` so re-runs do not fail if the same beta package version was already published.

The stable release workflow is unchanged in this PR. Reviewers should note that this workflow now depends on the `nuget-beta` environment having a `NUGET_USER` secret and on a matching trusted publishing policy on nuget.org for `dotnet-main.yml`.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

This change is limited to `dotnet-main.yml` so we can trial trusted publishing on the beta feed before making the same change elsewhere.