### PR TITLE
Add Squad integration CODEOWNERS entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -143,3 +143,9 @@
 /src/CommunityToolkit.Aspire.Hosting.Perl/ @Omnideth
 /tests/CommunityToolkit.Aspire.Hosting.Perl.Tests/ @Omnideth
 /examples/perl/ @Omnideth
+
+# CommunityToolkit.Aspire.Hosting.Squad
+
+/src/CommunityToolkit.Aspire.Hosting.Squad/ @tamirdresher
+/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/ @tamirdresher
+/examples/squad/ @tamirdresher


### PR DESCRIPTION
**Closes:** N/A

This updates `CODEOWNERS` so the Squad integration routes reviews to `@tamirdresher`. It adds ownership for the Squad source, tests, and example paths to keep review routing consistent across the integration.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

Tests and API doc updates are not applicable for this `CODEOWNERS`-only change.