### PR TITLE
Fix cross-platform Copilot CLI launch in Squad hosting integration

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Squad/SquadBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Squad/SquadBuilderExtensions.cs
@@ -209,102 +209,215 @@ public static class SquadBuilderExtensions
         {
             if (OperatingSystem.IsWindows())
             {
-                LaunchCopilotCliWindows(teamRoot, windowTitle);
+                LaunchCopilotCliWindows(squadName, teamRoot, windowTitle);
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                LaunchCopilotCliMacOs(squadName, teamRoot);
+            }
+            else if (OperatingSystem.IsLinux())
+            {
+                if (!LaunchCopilotCliLinux(squadName, teamRoot))
+                {
+                    return LaunchResult.Failed(
+                        "Could not open a terminal for GitHub Copilot CLI: no supported terminal emulator " +
+                        "(x-terminal-emulator, gnome-terminal, konsole, xfce4-terminal, xterm) was found on PATH. " +
+                        "Install one, or run 'copilot --agent squad' manually from the squad workspace.");
+                }
             }
             else
             {
-                LaunchCopilotCliUnix(teamRoot, windowTitle);
+                return LaunchResult.Failed("Opening GitHub Copilot CLI is not supported on this operating system.");
             }
 
             return LaunchResult.Succeeded($"Opened GitHub Copilot CLI for squad '{squadName}'.");
         }
-        catch (Exception ex) when (ex is Win32Exception or FileNotFoundException or InvalidOperationException)
+        catch (Exception ex) when (ex is Win32Exception or FileNotFoundException or InvalidOperationException or IOException)
         {
             return LaunchResult.Failed($"Failed to open Copilot CLI terminal: {ex.Message}");
         }
     }
 
-    // OS-bound spawn helpers — excluded from coverage because they hand off to terminal
-    // processes. Their argument-list building is simple enough to read at a glance;
-    // the launch itself can only be exercised in a user-driven smoke test.
-    [ExcludeFromCodeCoverage]
-    private static void LaunchCopilotCliWindows(string teamRoot, string windowTitle)
+    // Copilot is always launched from a temporary SCRIPT FILE written under
+    // <teamRoot>/.squad/.cache/. Running a file means no terminal — in particular
+    // Windows Terminal, which treats ';' as a pane/command separator — ever has to
+    // parse ';', '&', or quotes out of an inline command string, which is what caused
+    // wt.exe to fail with Win32 error 0x80070002 (ERROR_FILE_NOT_FOUND).
+    private static string WriteLaunchScript(string teamRoot, string squadName, string extension, string content, bool makeExecutable)
     {
-        var copilotCommand = "$copilot = Get-Command copilot -ErrorAction SilentlyContinue; " +
-            "if ($copilot) { & $copilot.Source } " +
-            "else { Write-Host 'GitHub Copilot CLI was not found on PATH. Install it or add copilot to PATH, then retry from Aspire.' -ForegroundColor Yellow }";
+        var cacheDir = Path.Combine(teamRoot, ".squad", ".cache");
+        Directory.CreateDirectory(cacheDir);
 
-        // Try Windows Terminal first, fall back to PowerShell console.
+        // Unique per launch so re-launching never contends with a file that is still
+        // locked/open by a previously spawned terminal.
+        var fileName = $"launch-copilot-{SanitizeFileComponent(squadName)}-{DateTime.Now:yyyyMMddHHmmssfff}{extension}";
+        var scriptPath = Path.Combine(cacheDir, fileName);
+
+        File.WriteAllText(scriptPath, content);
+
+        // Guarded so File.SetUnixFileMode is only invoked on Unix (it throws on Windows).
+        if (makeExecutable && !OperatingSystem.IsWindows())
+        {
+            // rwxr-xr-x (0755)
+            File.SetUnixFileMode(
+                scriptPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
+
+        return scriptPath;
+    }
+
+    private static string SanitizeFileComponent(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var cleaned = new string(value.Select(c => Array.IndexOf(invalid, c) >= 0 ? '-' : c).ToArray()).Trim();
+        return string.IsNullOrEmpty(cleaned) ? "squad" : cleaned;
+    }
+
+    private static string BuildUnixLaunchScript(string teamRoot)
+    {
+        // bash single-quoted string escaping: ' -> '\''
+        var escapedRoot = teamRoot.Replace("'", "'\\''");
+
+        // Join with '\n' (not Environment.NewLine) so the script keeps LF endings on all hosts.
+        return string.Join('\n',
+            "#!/bin/bash",
+            $"cd '{escapedRoot}'",
+            "if command -v copilot >/dev/null 2>&1; then",
+            "    copilot --agent squad",
+            "else",
+            "    echo 'GitHub Copilot CLI was not found on PATH. Install it or add copilot to PATH, then retry from Aspire.'",
+            "fi",
+            "exec \"${SHELL:-/bin/bash}\"") + "\n";
+    }
+
+    // OS-bound spawn helpers — excluded from coverage because they hand off to terminal
+    // processes. The launch itself can only be exercised in a user-driven smoke test.
+    [ExcludeFromCodeCoverage]
+    private static void LaunchCopilotCliWindows(string squadName, string teamRoot, string windowTitle)
+    {
+        // PowerShell single-quoted string escaping: ' -> ''
+        var escapedRoot = teamRoot.Replace("'", "''");
+
+        var script = string.Join(
+            Environment.NewLine,
+            $"Set-Location -LiteralPath '{escapedRoot}'",
+            "$copilot = Get-Command copilot -ErrorAction SilentlyContinue",
+            "if ($copilot) { & $copilot.Source --agent squad } " +
+            "else { Write-Host 'GitHub Copilot CLI was not found on PATH. Install it or add copilot to PATH, then retry from Aspire.' -ForegroundColor Yellow }") + Environment.NewLine;
+
+        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".ps1", script, makeExecutable: false);
+
+        // Prefer Windows Terminal (wt.exe), running the script FILE with -File.
         try
         {
-            var startInfo = new ProcessStartInfo
+            var wt = new ProcessStartInfo
             {
                 FileName = "wt.exe",
                 UseShellExecute = false,
             };
 
-            startInfo.ArgumentList.Add("-d");
-            startInfo.ArgumentList.Add(teamRoot);
-            startInfo.ArgumentList.Add("--title");
-            startInfo.ArgumentList.Add(windowTitle);
-            startInfo.ArgumentList.Add("powershell.exe");
-            startInfo.ArgumentList.Add("-NoLogo");
-            startInfo.ArgumentList.Add("-NoExit");
-            startInfo.ArgumentList.Add("-Command");
-            startInfo.ArgumentList.Add(copilotCommand);
+            wt.ArgumentList.Add("-d");
+            wt.ArgumentList.Add(teamRoot);
+            wt.ArgumentList.Add("--title");
+            wt.ArgumentList.Add(windowTitle);
+            wt.ArgumentList.Add("powershell");
+            wt.ArgumentList.Add("-NoLogo");
+            wt.ArgumentList.Add("-NoExit");
+            wt.ArgumentList.Add("-File");
+            wt.ArgumentList.Add(scriptPath);
 
-            Process.Start(startInfo);
+            Process.Start(wt);
             return;
         }
-        catch (Exception ex) when (ex is Win32Exception or FileNotFoundException or InvalidOperationException)
+        catch (Exception ex) when (ex is Win32Exception or FileNotFoundException)
         {
-            // Windows Terminal is optional. Fall back to the inbox console host.
+            // Windows Terminal is not installed. Fall back to a plain console window.
         }
 
-        // Fallback: launch PowerShell directly (opens a new console window via UseShellExecute=true).
-        var escapedTitle = windowTitle.Replace("'", "''");
-        var inlineCommand = $"$Host.UI.RawUI.WindowTitle = '{escapedTitle}'; {copilotCommand}";
-
-        var fallbackInfo = new ProcessStartInfo
+        // Fallback: cmd's built-in `start` opens a new console window. The first quoted
+        // token after `start` becomes the window title.
+        var fallback = new ProcessStartInfo
         {
-            FileName = "powershell.exe",
-            WorkingDirectory = teamRoot,
-            UseShellExecute = true,
-        };
-
-        fallbackInfo.ArgumentList.Add("-NoLogo");
-        fallbackInfo.ArgumentList.Add("-NoExit");
-        fallbackInfo.ArgumentList.Add("-Command");
-        fallbackInfo.ArgumentList.Add(inlineCommand);
-
-        Process.Start(fallbackInfo);
-    }
-
-    [ExcludeFromCodeCoverage]
-    private static void LaunchCopilotCliUnix(string teamRoot, string windowTitle)
-    {
-        // On macOS/Linux, launch a shell that checks for the copilot CLI.
-        var shellCommand = "command -v copilot >/dev/null 2>&1 && exec copilot || " +
-            "{ echo 'GitHub Copilot CLI was not found on PATH. Install it or add copilot to PATH, then retry from Aspire.'; exec $SHELL; }";
-
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = GetUnixShell(),
+            FileName = "cmd.exe",
             WorkingDirectory = teamRoot,
             UseShellExecute = false,
         };
 
-        startInfo.ArgumentList.Add("-c");
-        startInfo.ArgumentList.Add(shellCommand);
-        startInfo.Environment["SQUAD_TERMINAL_TITLE"] = windowTitle;
+        fallback.ArgumentList.Add("/c");
+        fallback.ArgumentList.Add("start");
+        fallback.ArgumentList.Add(windowTitle);
+        fallback.ArgumentList.Add("powershell");
+        fallback.ArgumentList.Add("-NoLogo");
+        fallback.ArgumentList.Add("-NoExit");
+        fallback.ArgumentList.Add("-File");
+        fallback.ArgumentList.Add(scriptPath);
 
-        Process.Start(startInfo);
+        Process.Start(fallback);
     }
 
-    private static string GetUnixShell()
+    [ExcludeFromCodeCoverage]
+    private static void LaunchCopilotCliMacOs(string squadName, string teamRoot)
     {
-        var shell = Environment.GetEnvironmentVariable("SHELL");
-        return !string.IsNullOrEmpty(shell) ? shell : "/bin/bash";
+        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".command", BuildUnixLaunchScript(teamRoot), makeExecutable: true);
+
+        var open = new ProcessStartInfo
+        {
+            FileName = "open",
+            UseShellExecute = false,
+        };
+
+        open.ArgumentList.Add("-a");
+        open.ArgumentList.Add("Terminal");
+        open.ArgumentList.Add(scriptPath);
+
+        Process.Start(open);
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static bool LaunchCopilotCliLinux(string squadName, string teamRoot)
+    {
+        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".sh", BuildUnixLaunchScript(teamRoot), makeExecutable: true);
+
+        // Terminal emulators vary across distros; try the common ones in order and fall
+        // through to the next when one is not installed (Win32Exception/FileNotFoundException).
+        (string FileName, string[] Args)[] candidates =
+        [
+            ("x-terminal-emulator", ["-e", "bash", scriptPath]),
+            ("gnome-terminal", ["--", "bash", scriptPath]),
+            ("konsole", ["-e", "bash", scriptPath]),
+            ("xfce4-terminal", ["-x", "bash", scriptPath]),
+            ("xterm", ["-e", "bash", scriptPath]),
+        ];
+
+        foreach (var (fileName, args) in candidates)
+        {
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = fileName,
+                    WorkingDirectory = teamRoot,
+                    UseShellExecute = false,
+                };
+
+                foreach (var arg in args)
+                {
+                    startInfo.ArgumentList.Add(arg);
+                }
+
+                Process.Start(startInfo);
+                return true;
+            }
+            catch (Exception ex) when (ex is Win32Exception or FileNotFoundException)
+            {
+                // Emulator not present; try the next candidate.
+            }
+        }
+
+        return false;
     }
 
     private sealed record LaunchResult(bool Success, string Message)

--- a/src/CommunityToolkit.Aspire.Hosting.Squad/SquadBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Squad/SquadBuilderExtensions.cs
@@ -232,7 +232,7 @@ public static class SquadBuilderExtensions
 
             return LaunchResult.Succeeded($"Opened GitHub Copilot CLI for squad '{squadName}'.");
         }
-        catch (Exception ex) when (ex is Win32Exception or FileNotFoundException or InvalidOperationException or IOException)
+        catch (Exception ex) when (ex is Win32Exception or FileNotFoundException or InvalidOperationException or IOException or UnauthorizedAccessException)
         {
             return LaunchResult.Failed($"Failed to open Copilot CLI terminal: {ex.Message}");
         }
@@ -248,9 +248,10 @@ public static class SquadBuilderExtensions
         var cacheDir = Path.Combine(teamRoot, ".squad", ".cache");
         Directory.CreateDirectory(cacheDir);
 
-        // Unique per launch so re-launching never contends with a file that is still
-        // locked/open by a previously spawned terminal.
-        var fileName = $"launch-copilot-{SanitizeFileComponent(squadName)}-{DateTime.Now:yyyyMMddHHmmssfff}{extension}";
+        // Unique per launch (timestamp + random token) so re-launching never contends with a
+        // file that is still locked/open by a previously spawned terminal. The GUID guards against
+        // coarse clock granularity (~15ms on Windows) producing duplicate timestamps for rapid launches.
+        var fileName = $"launch-copilot-{SanitizeFileComponent(squadName)}-{DateTime.Now:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}{extension}";
         var scriptPath = Path.Combine(cacheDir, fileName);
 
         File.WriteAllText(scriptPath, content);
@@ -276,7 +277,7 @@ public static class SquadBuilderExtensions
         return string.IsNullOrEmpty(cleaned) ? "squad" : cleaned;
     }
 
-    private static string BuildUnixLaunchScript(string teamRoot)
+    internal static string BuildUnixLaunchScript(string teamRoot)
     {
         // bash single-quoted string escaping: ' -> '\''
         var escapedRoot = teamRoot.Replace("'", "'\\''");
@@ -293,20 +294,28 @@ public static class SquadBuilderExtensions
             "exec \"${SHELL:-/bin/bash}\"") + "\n";
     }
 
-    // OS-bound spawn helpers — excluded from coverage because they hand off to terminal
-    // processes. The launch itself can only be exercised in a user-driven smoke test.
-    [ExcludeFromCodeCoverage]
-    private static void LaunchCopilotCliWindows(string squadName, string teamRoot, string windowTitle)
+    internal static string BuildWindowsLaunchScript(string teamRoot)
     {
         // PowerShell single-quoted string escaping: ' -> ''
         var escapedRoot = teamRoot.Replace("'", "''");
 
-        var script = string.Join(
+        // Newline-separated statements (Environment.NewLine) written to a .ps1 FILE and run with
+        // -File. This is deliberately NOT a single ';'-joined inline command: passing such a string
+        // to wt.exe made Windows Terminal treat ';' as a pane separator and fail with 0x80070002.
+        return string.Join(
             Environment.NewLine,
             $"Set-Location -LiteralPath '{escapedRoot}'",
             "$copilot = Get-Command copilot -ErrorAction SilentlyContinue",
             "if ($copilot) { & $copilot.Source --agent squad } " +
             "else { Write-Host 'GitHub Copilot CLI was not found on PATH. Install it or add copilot to PATH, then retry from Aspire.' -ForegroundColor Yellow }") + Environment.NewLine;
+    }
+
+    // OS-bound spawn helpers — excluded from coverage because they hand off to terminal
+    // processes. The launch itself can only be exercised in a user-driven smoke test.
+    [ExcludeFromCodeCoverage]
+    private static void LaunchCopilotCliWindows(string squadName, string teamRoot, string windowTitle)
+    {
+        var script = BuildWindowsLaunchScript(teamRoot);
 
         var scriptPath = WriteLaunchScript(teamRoot, squadName, ".ps1", script, makeExecutable: false);
 

--- a/src/CommunityToolkit.Aspire.Hosting.Squad/SquadBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Squad/SquadBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Aspire.Hosting.Lifecycle;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 #pragma warning disable ASPIREATS001 // AspireExport is experimental
 
@@ -238,12 +239,20 @@ public static class SquadBuilderExtensions
         }
     }
 
+    // Windows PowerShell 5.1 misreads UTF-8-without-BOM content as ANSI, which corrupts any
+    // non-ASCII characters embedded in the generated .ps1 (e.g. a teamRoot path inside
+    // Set-Location -LiteralPath '…'). Emitting a BOM makes 5.1 decode the script as UTF-8.
+    internal static readonly Encoding WindowsScriptEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+
+    // Unix scripts must stay BOM-free: a leading BOM breaks the '#!/bin/bash' shebang. LF-only.
+    internal static readonly Encoding UnixScriptEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     // Copilot is always launched from a temporary SCRIPT FILE written under
     // <teamRoot>/.squad/.cache/. Running a file means no terminal — in particular
     // Windows Terminal, which treats ';' as a pane/command separator — ever has to
     // parse ';', '&', or quotes out of an inline command string, which is what caused
     // wt.exe to fail with Win32 error 0x80070002 (ERROR_FILE_NOT_FOUND).
-    private static string WriteLaunchScript(string teamRoot, string squadName, string extension, string content, bool makeExecutable)
+    internal static string WriteLaunchScript(string teamRoot, string squadName, string extension, string content, bool makeExecutable, Encoding encoding)
     {
         var cacheDir = Path.Combine(teamRoot, ".squad", ".cache");
         Directory.CreateDirectory(cacheDir);
@@ -254,7 +263,9 @@ public static class SquadBuilderExtensions
         var fileName = $"launch-copilot-{SanitizeFileComponent(squadName)}-{DateTime.Now:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}{extension}";
         var scriptPath = Path.Combine(cacheDir, fileName);
 
-        File.WriteAllText(scriptPath, content);
+        // Windows scripts are written UTF-8 WITH BOM (see WindowsScriptEncoding); Unix scripts
+        // UTF-8 WITHOUT BOM (see UnixScriptEncoding) so the shebang stays intact.
+        File.WriteAllText(scriptPath, content, encoding);
 
         // Guarded so File.SetUnixFileMode is only invoked on Unix (it throws on Windows).
         if (makeExecutable && !OperatingSystem.IsWindows())
@@ -317,7 +328,7 @@ public static class SquadBuilderExtensions
     {
         var script = BuildWindowsLaunchScript(teamRoot);
 
-        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".ps1", script, makeExecutable: false);
+        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".ps1", script, makeExecutable: false, WindowsScriptEncoding);
 
         // Prefer Windows Terminal (wt.exe), running the script FILE with -File.
         try
@@ -370,7 +381,7 @@ public static class SquadBuilderExtensions
     [ExcludeFromCodeCoverage]
     private static void LaunchCopilotCliMacOs(string squadName, string teamRoot)
     {
-        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".command", BuildUnixLaunchScript(teamRoot), makeExecutable: true);
+        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".command", BuildUnixLaunchScript(teamRoot), makeExecutable: true, UnixScriptEncoding);
 
         var open = new ProcessStartInfo
         {
@@ -388,7 +399,7 @@ public static class SquadBuilderExtensions
     [ExcludeFromCodeCoverage]
     private static bool LaunchCopilotCliLinux(string squadName, string teamRoot)
     {
-        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".sh", BuildUnixLaunchScript(teamRoot), makeExecutable: true);
+        var scriptPath = WriteLaunchScript(teamRoot, squadName, ".sh", BuildUnixLaunchScript(teamRoot), makeExecutable: true, UnixScriptEncoding);
 
         // Terminal emulators vary across distros; try the common ones in order and fall
         // through to the next when one is not installed (Win32Exception/FileNotFoundException).

--- a/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/SquadBuilderCommandsTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/SquadBuilderCommandsTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.DependencyInjection;
@@ -125,6 +126,94 @@ public class SquadBuilderCommandsTests : IDisposable
         Assert.True(result.Success);
     }
 
+    [Fact]
+    public async Task OpenCopilotCli_OnLinux_WritesScript_RunsCopilotWithAgentSquad()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+        if (!OperatingSystem.IsLinux())
+        {
+            // macOS launcher uses `open -a Terminal`, which cannot be faked headlessly.
+            return;
+        }
+
+        var teamRoot = CreateTeamRoot();
+        Directory.CreateDirectory(Path.Combine(teamRoot, ".squad"));
+
+        var binDir = Path.Combine(Path.GetTempPath(), "ctk-aspire-squad-fakebin", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(binDir);
+        _tempRoots.Add(binDir);
+
+        var marker = Path.Combine(binDir, "copilot-invocation.txt");
+
+        var fakeEmulator = Path.Combine(binDir, "x-terminal-emulator");
+        File.WriteAllText(fakeEmulator, "#!/bin/bash\nshift            # drop -e\nexec \"$@\" </dev/null\n");
+        MakeExecutable(fakeEmulator);
+
+        var fakeCopilot = Path.Combine(binDir, "copilot");
+        File.WriteAllText(fakeCopilot, "#!/bin/bash\n" + $"echo \"args=$*\" > '{marker}'\n" + $"echo \"cwd=$(pwd)\" >> '{marker}'\n");
+        MakeExecutable(fakeCopilot);
+
+        var resource = BuildSquadResourceForExistingRoot("squad", teamRoot);
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", binDir + Path.PathSeparator + originalPath);
+            var result = await InvokeCommandAsync(resource, "open-copilot-cli");
+            Assert.True(result.Success, $"Expected launch to succeed; message: {result.Message}");
+
+            var deadline = DateTime.UtcNow.AddSeconds(10);
+            while (!File.Exists(marker) && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(100);
+            }
+            Assert.True(File.Exists(marker), "Fake copilot never wrote its marker — script did not reach `copilot --agent squad`.");
+
+            var proof = File.ReadAllText(marker);
+            Assert.Contains("--agent squad", proof);
+            var cwdLine = proof.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(l => l.StartsWith("cwd=", StringComparison.Ordinal));
+            Assert.NotNull(cwdLine);
+            var reportedCwd = cwdLine!.Substring("cwd=".Length).Trim();
+            Assert.Equal(RealPath(teamRoot), RealPath(reportedCwd));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    [Fact]
+    public async Task OpenCopilotCli_WhenCacheDirCannotBeCreated_FailsGracefully()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+        if (GetEffectiveUid() <= 0)
+        {
+            // root (uid 0, typical in Docker) bypasses permission bits; -1 = couldn't determine.
+            return;
+        }
+
+        var teamRoot = CreateTeamRoot();
+        var resource = BuildSquadResourceForExistingRoot("squad", teamRoot);
+
+        File.SetUnixFileMode(teamRoot, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        try
+        {
+            var result = await InvokeCommandAsync(resource, "open-copilot-cli");
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.Message));
+        }
+        finally
+        {
+            File.SetUnixFileMode(teamRoot, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     // ─────────────────────────────── helpers ───────────────────────────────
 
     private SquadResource BuildSquadResource(string name, bool seedTeamMd = false)
@@ -184,6 +273,45 @@ public class SquadBuilderCommandsTests : IDisposable
         Directory.CreateDirectory(dir);
         _tempRoots.Add(dir);
         return dir;
+    }
+
+    private static void MakeExecutable(string path)
+    {
+        if (OperatingSystem.IsWindows()) return;
+        File.SetUnixFileMode(path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+    }
+
+    private static string RealPath(string path)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo { FileName = "realpath", UseShellExecute = false, RedirectStandardOutput = true };
+            psi.ArgumentList.Add(path);
+            using var p = Process.Start(psi);
+            if (p is null) return Path.TrimEndingDirectorySeparator(path);
+            var outp = p.StandardOutput.ReadToEnd().Trim();
+            p.WaitForExit(2000);
+            return string.IsNullOrEmpty(outp) ? Path.TrimEndingDirectorySeparator(path) : outp;
+        }
+        catch { return Path.TrimEndingDirectorySeparator(path); }
+    }
+
+    private static int GetEffectiveUid()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo { FileName = "id", UseShellExecute = false, RedirectStandardOutput = true };
+            psi.ArgumentList.Add("-u");
+            using var p = Process.Start(psi);
+            if (p is null) return -1;
+            var outp = p.StandardOutput.ReadToEnd().Trim();
+            p.WaitForExit(2000);
+            return int.TryParse(outp, out var uid) ? uid : -1;
+        }
+        catch { return -1; }
     }
 
     public void Dispose()

--- a/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/SquadBuilderCommandsTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/SquadBuilderCommandsTests.cs
@@ -11,11 +11,22 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace CommunityToolkit.Aspire.Hosting.Squad.Tests;
 
 /// <summary>
+/// Marks <see cref="SquadBuilderCommandsTests"/> as a non-parallel collection. That class mutates
+/// the process-wide PATH environment variable in its headless behavioral test, so it must never run
+/// concurrently with sibling test classes that could observe the mutated PATH mid-run.
+/// </summary>
+[CollectionDefinition("PathMutatingSerial", DisableParallelization = true)]
+public sealed class PathMutatingSerialCollection
+{
+}
+
+/// <summary>
 /// Exercises the dashboard commands attached to <see cref="SquadResource"/> by
 /// <c>SquadBuilderExtensions.AddSquad</c>. Each <c>WithCommand(...)</c> call lands as a
 /// <see cref="ResourceCommandAnnotation"/> on the resource; we invoke each command's
 /// <c>ExecuteCommand</c> delegate and assert the visible <see cref="ExecuteCommandResult"/>.
 /// </summary>
+[Collection("PathMutatingSerial")]
 public class SquadBuilderCommandsTests : IDisposable
 {
     private readonly List<string> _tempRoots = new();

--- a/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/SquadLaunchScriptTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/SquadLaunchScriptTests.cs
@@ -1,0 +1,94 @@
+using Aspire.Hosting;
+
+namespace CommunityToolkit.Aspire.Hosting.Squad.Tests;
+
+/// <summary>
+/// Pure, host-independent assertions over the launch-script builders in
+/// <see cref="SquadBuilderExtensions"/>. These run on every OS because they only inspect the
+/// generated script string — they never spawn a terminal. They lock in the cross-platform fix
+/// (a script FILE per OS, invoking <c>copilot --agent squad</c>) and guard against a regression
+/// to the original inline <c>;</c>-joined command that made <c>wt.exe</c> fail with 0x80070002.
+/// </summary>
+public class SquadLaunchScriptTests
+{
+    // ─────────────────────────── Windows (.ps1) ───────────────────────────
+
+    [Fact]
+    public void BuildWindowsLaunchScript_InvokesCopilotWithAgentSquad()
+    {
+        var script = SquadBuilderExtensions.BuildWindowsLaunchScript(@"C:\repos\proj");
+
+        Assert.Contains("--agent squad", script);
+    }
+
+    [Fact]
+    public void BuildWindowsLaunchScript_SetsLocationToTeamRoot()
+    {
+        var script = SquadBuilderExtensions.BuildWindowsLaunchScript(@"C:\repos\proj");
+
+        Assert.Contains(@"Set-Location -LiteralPath 'C:\repos\proj'", script);
+    }
+
+    [Fact]
+    public void BuildWindowsLaunchScript_DoublesSingleQuoteInTeamRoot()
+    {
+        // PowerShell single-quoted string escaping: ' -> ''
+        var script = SquadBuilderExtensions.BuildWindowsLaunchScript(@"C:\a'b");
+
+        Assert.Contains(@"Set-Location -LiteralPath 'C:\a''b'", script);
+    }
+
+    [Fact]
+    public void BuildWindowsLaunchScript_IsMultiLine_NotInlineSemicolonJoinedCommand()
+    {
+        // Regression guard for the original bug: the launch used to be a single
+        // "Set-Location ...; $copilot = ...; if (...)" string handed to wt.exe, which treats ';'
+        // as a pane separator and failed with Win32 0x80070002. The fix writes a multi-line .ps1
+        // FILE run via -File, so no terminal ever parses ';'.
+        var script = SquadBuilderExtensions.BuildWindowsLaunchScript(@"C:\repos\proj");
+
+        var lines = script.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.True(lines.Length >= 3, $"Expected a multi-line script but got {lines.Length} line(s).");
+        Assert.Equal(@"Set-Location -LiteralPath 'C:\repos\proj'", lines[0]);
+        // No ';' statement separators anywhere — that was the failing inline pattern.
+        Assert.DoesNotContain(";", script);
+        Assert.DoesNotContain("wt.exe", script);
+    }
+
+    // ──────────────────────────── Unix (.sh/.command) ────────────────────────────
+
+    [Fact]
+    public void BuildUnixLaunchScript_InvokesCopilotWithAgentSquad()
+    {
+        var script = SquadBuilderExtensions.BuildUnixLaunchScript("/home/me/proj");
+
+        Assert.Contains("copilot --agent squad", script);
+    }
+
+    [Fact]
+    public void BuildUnixLaunchScript_CdsToTeamRoot()
+    {
+        var script = SquadBuilderExtensions.BuildUnixLaunchScript("/home/me/proj");
+
+        Assert.Contains("cd '/home/me/proj'", script);
+    }
+
+    [Fact]
+    public void BuildUnixLaunchScript_EscapesSingleQuoteInTeamRoot()
+    {
+        // bash single-quoted string escaping: ' -> '\''
+        var script = SquadBuilderExtensions.BuildUnixLaunchScript("/home/m'e");
+
+        Assert.Contains(@"cd '/home/m'\''e'", script);
+    }
+
+    [Fact]
+    public void BuildUnixLaunchScript_UsesLfLineEndings()
+    {
+        var script = SquadBuilderExtensions.BuildUnixLaunchScript("/home/me/proj");
+
+        Assert.DoesNotContain("\r", script);
+        Assert.StartsWith("#!/bin/bash\n", script);
+    }
+}

--- a/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/SquadLaunchScriptTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/SquadLaunchScriptTests.cs
@@ -91,4 +91,88 @@ public class SquadLaunchScriptTests
         Assert.DoesNotContain("\r", script);
         Assert.StartsWith("#!/bin/bash\n", script);
     }
+
+    // ──────────────────────────── Encoding / BOM (FIX 1) ────────────────────────────
+
+    [Fact]
+    public void WriteLaunchScript_WindowsScript_StartsWithUtf8Bom()
+    {
+        // Windows PowerShell 5.1 misreads UTF-8-without-BOM as ANSI, corrupting a non-ASCII
+        // teamRoot embedded in Set-Location. The Windows .ps1 must be written UTF-8 WITH BOM.
+        var root = CreateTempRoot();
+        try
+        {
+            var content = SquadBuilderExtensions.BuildWindowsLaunchScript(root);
+            var path = SquadBuilderExtensions.WriteLaunchScript(
+                root, "squad", ".ps1", content, makeExecutable: false, SquadBuilderExtensions.WindowsScriptEncoding);
+
+            var bytes = File.ReadAllBytes(path);
+
+            Assert.True(bytes.Length >= 3, "Script file is unexpectedly small.");
+            Assert.Equal(0xEF, bytes[0]);
+            Assert.Equal(0xBB, bytes[1]);
+            Assert.Equal(0xBF, bytes[2]);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void WriteLaunchScript_UnixScript_HasNoBom()
+    {
+        // Unix scripts must stay BOM-free: a leading BOM breaks the #!/bin/bash shebang.
+        var root = CreateTempRoot();
+        try
+        {
+            var content = SquadBuilderExtensions.BuildUnixLaunchScript(root);
+            var path = SquadBuilderExtensions.WriteLaunchScript(
+                root, "squad", ".sh", content, makeExecutable: false, SquadBuilderExtensions.UnixScriptEncoding);
+
+            var bytes = File.ReadAllBytes(path);
+
+            Assert.True(bytes.Length >= 3, "Script file is unexpectedly small.");
+            var hasBom = bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+            Assert.False(hasBom, "Unix script must not start with a UTF-8 BOM.");
+            // Shebang must be the very first bytes so the kernel can exec the interpreter.
+            Assert.Equal((byte)'#', bytes[0]);
+            Assert.Equal((byte)'!', bytes[1]);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void WindowsScriptEncoding_EmitsUtf8Bom_UnixEncodingDoesNot()
+    {
+        Assert.Equal(3, SquadBuilderExtensions.WindowsScriptEncoding.GetPreamble().Length);
+        Assert.Empty(SquadBuilderExtensions.UnixScriptEncoding.GetPreamble());
+    }
+
+    // ─────────────────────────────── Helpers ───────────────────────────────
+
+    private static string CreateTempRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "squad-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; ignore.
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a cross-platform bug in the Squad hosting integration's **"Open Copilot CLI"** resource command (`src/CommunityToolkit.Aspire.Hosting.Squad/SquadBuilderExtensions.cs`). The command now launches GitHub Copilot CLI reliably on **Windows, macOS, and Linux**, and invokes it with the required `--agent squad` flag.

## Root cause

On Windows the command built an **inline, multi-statement PowerShell command string** (statements separated by `;`) and passed it to `wt.exe` (Windows Terminal). Windows Terminal treats `;` as a **pane/command separator**, so it split the string and tried to execute the fragment after the first `;` as a separate program. That failed with:

```
error 2147942402 (0x80070002)  // Win32 ERROR_FILE_NOT_FOUND
```

The intended `cmd /c start …` fallback never ran, because `wt.exe` **does** exist, so `Process.Start` didn't throw — the failure happened *inside* Windows Terminal's own argument parsing, not at process-launch time.

Additionally, the command:
- **hard-failed on non-Windows** (`return LaunchResult.Failed(...)` when `!OperatingSystem.IsWindows()`), so macOS/Linux were unsupported; and
- launched Copilot **without** the required `--agent squad` flag.

## The fix

Instead of handing an inline multi-statement command to a terminal, the launch logic is now written to a **temporary script FILE** under `<teamRoot>/.squad/.cache/` (created on demand), and the terminal is asked to run that **file**. Because the terminal only ever sees a single file path, **no terminal has to parse `;`, `&`, or quotes**, which eliminates the `0x80070002` failure entirely.

Dispatch is by `OperatingSystem.IsWindows()/IsMacOS()/IsLinux()`:

- **Windows** — writes a `.ps1` (newline-separated statements) and launches:
  `wt.exe -d <teamRoot> --title <title> powershell -NoLogo -NoExit -File <script.ps1>`.
  On `Win32Exception`/`FileNotFoundException` (Windows Terminal not installed) it falls back to
  `cmd /c start "<title>" powershell -NoLogo -NoExit -File <script.ps1>`.
- **macOS** — writes a `.command` (chmod `0755`) and launches `open -a Terminal <script.command>`.
- **Linux** — writes a `.sh` (chmod `0755`) and tries terminal emulators in order, each wrapped so a missing one falls through to the next:
  `x-terminal-emulator` → `gnome-terminal` → `konsole` → `xfce4-terminal` → `xterm`.
  If none launch, it returns `LaunchResult.Failed(...)` with a helpful message.

Other details:
- All OS paths invoke **`copilot --agent squad`** (verified against the flag used elsewhere in the repo).
- Single quotes in `teamRoot` are escaped correctly per script language (PowerShell `''`, bash `'\''`).
- `File.SetUnixFileMode(path, 0755)` is guarded with `!OperatingSystem.IsWindows()` so it only runs on Unix (it throws on Windows). Unix scripts are written with LF endings for shebang correctness.
- The `LaunchResult` record and the `WithCommand` registration call sites are unchanged — only the launch implementation and the new OS-specific helpers were added.

## Before / after

| | Before | After |
|---|---|---|
| **Windows + Windows Terminal** | `wt.exe` split the inline `;` command → `0x80070002` (ERROR_FILE_NOT_FOUND); Copilot never opened | Opens a Windows Terminal tab running the `.ps1`; Copilot starts with `--agent squad` |
| **Windows, no Windows Terminal** | Fallback unreachable | Falls back to `cmd start` running the same `.ps1` |
| **macOS** | Hard failure (`LaunchResult.Failed`) | Opens Terminal.app running a `.command`; Copilot starts with `--agent squad` |
| **Linux** | Hard failure (`LaunchResult.Failed`) | Opens the first available terminal emulator running a `.sh`; graceful failure message if none found |
| **Copilot flag** | launched without `--agent squad` | always `copilot --agent squad` |

## Testing

- `dotnet build src/CommunityToolkit.Aspire.Hosting.Squad/CommunityToolkit.Aspire.Hosting.Squad.csproj` — **0 warnings, 0 errors** (net8.0/net9.0/net10.0; `TreatWarningsAsErrors=true`).
- `dotnet test tests/CommunityToolkit.Aspire.Hosting.Squad.Tests/CommunityToolkit.Aspire.Hosting.Squad.Tests.csproj` — **all 28 tests pass**.

No new analyzers or tooling were introduced.
