### PR TITLE
Add integration code owner workflow

### DIFF
--- a/.github/scripts/update-codeowners.mjs
+++ b/.github/scripts/update-codeowners.mjs
@@ -60,8 +60,12 @@ if (ownershipLines.every((line) => content.includes(line))) {
     process.exit(0);
 }
 
+const packageHeader = packageIds.length === 1
+    ? `# ${packageIds[0]}`
+    : `# ${packageIds.join(", ")}`;
+
 const block = [
-    ...packageIds.map((packageId) => `# ${packageId}`),
+    packageHeader,
     "",
     ...ownershipLines,
     "",

--- a/.github/scripts/update-codeowners.mjs
+++ b/.github/scripts/update-codeowners.mjs
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+
+const codeownersPath = process.env.CODEOWNERS_PATH ?? "CODEOWNERS";
+const ownerLogin = process.env.CODEOWNER_LOGIN;
+const exampleFoldersJson = process.env.EXAMPLE_FOLDERS_JSON;
+const packageIdsJson = process.env.PACKAGE_IDS_JSON;
+
+if (!ownerLogin || !exampleFoldersJson || !packageIdsJson) {
+    throw new Error("CODEOWNER_LOGIN, EXAMPLE_FOLDERS_JSON, and PACKAGE_IDS_JSON are required.");
+}
+
+const exampleFolders = [...new Set(JSON.parse(exampleFoldersJson))];
+const packageIds = [...new Set(JSON.parse(packageIdsJson))];
+const owner = ownerLogin.startsWith("@") ? ownerLogin : `@${ownerLogin}`;
+const packageIdPattern = /^CommunityToolkit\.Aspire(?:\.Hosting)?(?:\.[A-Za-z0-9]+)+$/;
+const exampleFolderPattern = /^[a-z0-9-]+$/;
+
+if (exampleFolders.length === 0) {
+    throw new Error("At least one example folder is required.");
+}
+
+for (const exampleFolder of exampleFolders) {
+    if (!exampleFolderPattern.test(exampleFolder)) {
+        throw new Error(`Invalid example folder '${exampleFolder}'.`);
+    }
+}
+
+for (const packageId of packageIds) {
+    if (!packageIdPattern.test(packageId)) {
+        throw new Error(`Invalid package ID '${packageId}'.`);
+    }
+
+    if (packageId.endsWith(".Tests")) {
+        throw new Error(`Package ID '${packageId}' should not include the .Tests suffix.`);
+    }
+}
+
+const originalContent = fs.readFileSync(codeownersPath, "utf8");
+const content = originalContent.replace(/\r\n/g, "\n");
+const ownershipLines = [
+    ...exampleFolders.map((exampleFolder) => `/examples/${exampleFolder}/ ${owner}`),
+    ...packageIds.flatMap((packageId) => [
+        `/src/${packageId}/ ${owner}`,
+        `/tests/${packageId}.Tests/ ${owner}`,
+    ]),
+];
+
+for (const line of ownershipLines) {
+    const prefix = line.split(" ")[0];
+    const existingLine = content
+        .split("\n")
+        .find((entry) => entry.startsWith(`${prefix} `));
+
+    if (existingLine && existingLine !== line) {
+        throw new Error(`Conflicting CODEOWNERS entry already exists: '${existingLine}'.`);
+    }
+}
+
+if (ownershipLines.every((line) => content.includes(line))) {
+    process.exit(0);
+}
+
+const block = [
+    ...packageIds.map((packageId) => `# ${packageId}`),
+    "",
+    ...ownershipLines,
+    "",
+].join("\n");
+
+const updatedContent = `${content.trimEnd()}\n\n${block}\n`;
+fs.writeFileSync(codeownersPath, updatedContent, "utf8");

--- a/.github/workflows/integration-codeowner.yml
+++ b/.github/workflows/integration-codeowner.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   prompt-for-codeowner:
-    if: ${{ github.event_name == 'pull_request_target' && !github.event.pull_request.draft }}
+    if: ${{ github.repository_owner == 'CommunityToolkit' && github.event_name == 'pull_request_target' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -89,7 +89,7 @@ jobs:
             });
 
   handle-codeowner-response:
-    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.body == '/codeowner-accept' || github.event.comment.body == '/codeowner-reject') }}
+    if: ${{ github.repository_owner == 'CommunityToolkit' && github.event_name == 'issue_comment' && github.event.issue.pull_request && (startsWith(github.event.comment.body, '/codeowner-accept') || startsWith(github.event.comment.body, '/codeowner-reject')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -104,7 +104,9 @@ jobs:
             const core = require('@actions/core');
 
             const comment = context.payload.comment;
-            const accepted = comment.body.trim() === '/codeowner-accept';
+            const command = comment.body.trim();
+            const accepted = command === '/codeowner-accept';
+            const isValidCommand = accepted || command === '/codeowner-reject';
             const issue = context.payload.issue;
             const prNumber = issue.number;
             const pr = await github.rest.pulls.get({
@@ -157,6 +159,7 @@ jobs:
             core.setOutput('allowed', validationError ? 'false' : 'true');
             core.setOutput('example_folders_display', exampleFolders.map((folder) => `\`examples/${folder}/\``).join(', '));
             core.setOutput('example_folders_json', JSON.stringify(exampleFolders));
+            core.setOutput('is_valid_command', isValidCommand ? 'true' : 'false');
             core.setOutput('is_pr_author', isPrAuthor ? 'true' : 'false');
             core.setOutput('owner_login', pr.data.user.login);
             core.setOutput('package_ids_json', JSON.stringify(packageIds));
@@ -167,14 +170,14 @@ jobs:
             core.setOutput('needs_org_invite', accepted && isPrAuthor && !orgMember ? 'true' : 'false');
 
       - name: Check out repository
-        if: ${{ steps.metadata.outputs.accepted == 'true' && steps.metadata.outputs.allowed == 'true' }}
+        if: ${{ steps.metadata.outputs.is_valid_command == 'true' && steps.metadata.outputs.accepted == 'true' && steps.metadata.outputs.allowed == 'true' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Create or update CODEOWNERS pull request
         id: codeowners_pr
-        if: ${{ steps.metadata.outputs.accepted == 'true' && steps.metadata.outputs.allowed == 'true' }}
+        if: ${{ steps.metadata.outputs.is_valid_command == 'true' && steps.metadata.outputs.accepted == 'true' && steps.metadata.outputs.allowed == 'true' }}
         env:
           BRANCH_NAME: automation/codeowners-pr-${{ steps.metadata.outputs.pr_number }}
           CODEOWNER_LOGIN: ${{ steps.metadata.outputs.owner_login }}
@@ -245,6 +248,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Confirm response
+        if: ${{ steps.metadata.outputs.is_valid_command == 'true' }}
         uses: actions/github-script@v9.0.0
         env:
           ACCEPTED: ${{ steps.metadata.outputs.accepted }}

--- a/.github/workflows/integration-codeowner.yml
+++ b/.github/workflows/integration-codeowner.yml
@@ -1,0 +1,296 @@
+name: Integration code owner automation
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  prompt-for-codeowner:
+    if: ${{ github.event_name == 'pull_request_target' && !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: write
+    steps:
+      - name: Detect new integration paths
+        id: metadata
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const core = require('@actions/core');
+
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const addedFiles = files.filter((file) => file.status === 'added' || file.status === 'renamed');
+            const packageIds = [...new Set(addedFiles
+              .map((file) => file.filename.match(/^src\/(CommunityToolkit\.Aspire(?:\.Hosting)?(?:\.[A-Za-z0-9]+)+)\/([^/]+)$/))
+              .filter((match) => match && match[2] === `${match[1]}.csproj`)
+              .map((match) => match[1]))];
+            const exampleFolders = [...new Set(addedFiles
+              .map((file) => file.filename.match(/^examples\/([a-z0-9-]+)\//))
+              .filter(Boolean)
+              .map((match) => match[1]))];
+
+            core.setOutput('package_ids_json', JSON.stringify(packageIds));
+            core.setOutput('example_folders_json', JSON.stringify(exampleFolders));
+            core.setOutput('is_new_integration', packageIds.length > 0 && exampleFolders.length > 0 ? 'true' : 'false');
+
+      - name: Prompt for code owner interest
+        if: ${{ steps.metadata.outputs.is_new_integration == 'true' }}
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const marker = '<!-- integration-codeowner-prompt -->';
+            const prNumber = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const author = context.payload.pull_request.user.login;
+            const body = `${marker}
+            Thanks for opening a new integration PR, @${author}.
+
+            If you want to become the code owner for this integration, reply with:
+            - \`/codeowner-accept\`
+            - \`/codeowner-reject\`
+
+            Only the PR author should use these commands.`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) => comment.body.includes(marker));
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  handle-codeowner-response:
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.body == '/codeowner-accept' || github.event.comment.body == '/codeowner-reject') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Collect PR metadata
+        id: metadata
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const core = require('@actions/core');
+
+            const comment = context.payload.comment;
+            const accepted = comment.body.trim() === '/codeowner-accept';
+            const issue = context.payload.issue;
+            const prNumber = issue.number;
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            const packageIdPattern = /^CommunityToolkit\.Aspire(?:\.Hosting)?(?:\.[A-Za-z0-9]+)+$/;
+            const exampleFolderPattern = /^[a-z0-9-]+$/;
+            const addedFiles = files.filter((file) => file.status === 'added' || file.status === 'renamed');
+            const packageIds = [...new Set(addedFiles
+              .map((file) => file.filename.match(/^src\/(CommunityToolkit\.Aspire(?:\.Hosting)?(?:\.[A-Za-z0-9]+)+)\/([^/]+)$/))
+              .filter((match) => match && match[2] === `${match[1]}.csproj`)
+              .map((match) => match[1]))];
+            const exampleFolders = [...new Set(addedFiles
+              .map((file) => file.filename.match(/^examples\/([a-z0-9-]+)\//))
+              .filter(Boolean)
+              .map((match) => match[1]))];
+
+            let validationError = '';
+
+            if (comment.user.login !== pr.data.user.login) {
+              validationError = `Only @${pr.data.user.login} can respond to the code owner prompt for this pull request.`;
+            } else if (pr.data.draft) {
+              validationError = 'This automation only runs after the pull request is ready for review.';
+            } else if (accepted) {
+              if (packageIds.length === 0) {
+                validationError = 'I could not find any new integration packages under `src/` in this pull request.';
+              } else if (exampleFolders.length === 0) {
+                validationError = 'I could not find any integration example folders under `examples/` in this pull request.';
+              } else if (packageIds.some((packageId) => !packageIdPattern.test(packageId) || packageId.endsWith('.Tests'))) {
+                validationError = 'This pull request contains an invalid integration package path.';
+              } else if (exampleFolders.some((exampleFolder) => !exampleFolderPattern.test(exampleFolder))) {
+                validationError = 'This pull request contains an invalid example folder path.';
+              }
+            }
+
+            const orgMemberAssociations = new Set(['MEMBER', 'OWNER']);
+            const isPrAuthor = comment.user.login === pr.data.user.login;
+            const orgMember = orgMemberAssociations.has(comment.author_association);
+
+            core.setOutput('accepted', accepted ? 'true' : 'false');
+            core.setOutput('allowed', validationError ? 'false' : 'true');
+            core.setOutput('example_folders_display', exampleFolders.map((folder) => `\`examples/${folder}/\``).join(', '));
+            core.setOutput('example_folders_json', JSON.stringify(exampleFolders));
+            core.setOutput('is_pr_author', isPrAuthor ? 'true' : 'false');
+            core.setOutput('owner_login', pr.data.user.login);
+            core.setOutput('package_ids_json', JSON.stringify(packageIds));
+            core.setOutput('package_ids_markdown', packageIds.map((packageId) => `- \`${packageId}\``).join('\n'));
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('pr_url', pr.data.html_url);
+            core.setOutput('validation_error', validationError);
+            core.setOutput('needs_org_invite', accepted && isPrAuthor && !orgMember ? 'true' : 'false');
+
+      - name: Check out repository
+        if: ${{ steps.metadata.outputs.accepted == 'true' && steps.metadata.outputs.allowed == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create or update CODEOWNERS pull request
+        id: codeowners_pr
+        if: ${{ steps.metadata.outputs.accepted == 'true' && steps.metadata.outputs.allowed == 'true' }}
+        env:
+          BRANCH_NAME: automation/codeowners-pr-${{ steps.metadata.outputs.pr_number }}
+          CODEOWNER_LOGIN: ${{ steps.metadata.outputs.owner_login }}
+          CODEOWNERS_PATH: CODEOWNERS
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXAMPLE_FOLDERS_JSON: ${{ steps.metadata.outputs.example_folders_json }}
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_IDS_JSON: ${{ steps.metadata.outputs.package_ids_json }}
+          PACKAGE_IDS_MARKDOWN: ${{ steps.metadata.outputs.package_ids_markdown }}
+          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+          PR_URL: ${{ steps.metadata.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin "${DEFAULT_BRANCH}"
+
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" > /dev/null 2>&1; then
+            git fetch origin "${BRANCH_NAME}"
+            git checkout -B "${BRANCH_NAME}" "origin/${BRANCH_NAME}"
+          else
+            git checkout -B "${BRANCH_NAME}" "origin/${DEFAULT_BRANCH}"
+          fi
+
+          node .github/scripts/update-codeowners.mjs
+
+          changed=false
+          if ! git diff --quiet -- CODEOWNERS; then
+            changed=true
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add CODEOWNERS
+            git commit -m "Add code owner for integration PR #${PR_NUMBER}"
+            git push --force-with-lease --set-upstream origin "${BRANCH_NAME}"
+          fi
+
+          pr_number="$(gh pr list --state open --head "${BRANCH_NAME}" --json number --jq '.[0].number // ""')"
+
+          if [ -z "${pr_number}" ] && [ "${changed}" = "true" ]; then
+            pr_body_file="$(mktemp)"
+            {
+              echo 'This pull request updates `CODEOWNERS` for a new integration submission.'
+              echo
+              echo "- Source PR: ${PR_URL}"
+              echo "- Proposed code owner: @${CODEOWNER_LOGIN}"
+              echo '- Package IDs:'
+              printf '%s\n' "${PACKAGE_IDS_MARKDOWN}"
+            } > "${pr_body_file}"
+
+            gh pr create \
+              --base "${DEFAULT_BRANCH}" \
+              --head "${BRANCH_NAME}" \
+              --title "Add CODEOWNERS entry for integration PR #${PR_NUMBER}" \
+              --body-file "${pr_body_file}"
+
+            rm -f "${pr_body_file}"
+            pr_number="$(gh pr list --state open --head "${BRANCH_NAME}" --json number --jq '.[0].number // ""')"
+          fi
+
+          pr_url=""
+          if [ -n "${pr_number}" ]; then
+            pr_url="$(gh pr view "${pr_number}" --json url --jq '.url')"
+          fi
+
+          {
+            echo "changed=${changed}"
+            echo "pr_number=${pr_number}"
+            echo "pr_url=${pr_url}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Confirm response
+        uses: actions/github-script@v9.0.0
+        env:
+          ACCEPTED: ${{ steps.metadata.outputs.accepted }}
+          ALLOWED: ${{ steps.metadata.outputs.allowed }}
+          CODEOWNERS_CHANGED: ${{ steps.codeowners_pr.outputs.changed }}
+          CODEOWNERS_PR_URL: ${{ steps.codeowners_pr.outputs.pr_url }}
+          EXAMPLE_FOLDERS_DISPLAY: ${{ steps.metadata.outputs.example_folders_display }}
+          IS_PR_AUTHOR: ${{ steps.metadata.outputs.is_pr_author }}
+          NEEDS_ORG_INVITE: ${{ steps.metadata.outputs.needs_org_invite }}
+          OWNER_LOGIN: ${{ steps.metadata.outputs.owner_login }}
+          VALIDATION_ERROR: ${{ steps.metadata.outputs.validation_error }}
+        with:
+          script: |
+            const accepted = process.env.ACCEPTED === 'true';
+            const allowed = process.env.ALLOWED === 'true';
+            const changed = process.env.CODEOWNERS_CHANGED === 'true';
+            const prUrl = process.env.CODEOWNERS_PR_URL;
+            const exampleFoldersDisplay = process.env.EXAMPLE_FOLDERS_DISPLAY;
+            const isPrAuthor = process.env.IS_PR_AUTHOR === 'true';
+            const needsOrgInvite = process.env.NEEDS_ORG_INVITE === 'true';
+            const ownerLogin = process.env.OWNER_LOGIN;
+            const validationError = process.env.VALIDATION_ERROR;
+
+            let body;
+
+            if (!allowed && !isPrAuthor) {
+              body = `@${context.payload.comment.user.login} ${validationError}`;
+            } else if (!allowed && accepted) {
+              body = `Thanks @${ownerLogin} — I have recorded that you want to own this integration, but I could not update \`CODEOWNERS\` automatically. ${validationError}`;
+            } else if (!accepted) {
+              body = `Thanks @${ownerLogin} — I have recorded that you do not want to be added as the code owner for this integration.`;
+            } else if (prUrl) {
+              body = `Thanks @${ownerLogin} — I have recorded that you want to own this integration and opened or updated ${prUrl} to add you to \`CODEOWNERS\` for ${exampleFoldersDisplay}.`;
+            } else if (changed) {
+              body = `Thanks @${ownerLogin} — I have recorded that you want to own this integration and updated the automation branch with the \`CODEOWNERS\` change.`;
+            } else {
+              body = `Thanks @${ownerLogin} — I have recorded that you want to own this integration. The requested \`CODEOWNERS\` entries are already present, so there was nothing else to update.`;
+            }
+
+            if (accepted && needsOrgInvite) {
+              body += `\n\n@CommunityToolkit/aspire-owners please add @${ownerLogin} to the organization so the \`CODEOWNERS\` entry can be used.`;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });


### PR DESCRIPTION
N/A (no linked issue provided)

Adds PR-based automation for new integration submissions so code owner assignment is only handled after a PR is ready for review. The workflow detects newly added integration packages and example folders from the PR, prompts the author with `/codeowner-accept` and `/codeowner-reject`, confirms the response, and opens or updates a separate PR to add the matching `CODEOWNERS` entries when ownership is accepted.

The `update-codeowners.mjs` helper centralizes the `CODEOWNERS` mutation so the workflow can reuse the repository's existing pattern safely, including conflict detection and support for multiple example folders or package IDs. It also tags `@CommunityToolkit/aspire-owners` when the accepting author is not currently an org member.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration (N/A)
  - [ ] Docs are written (N/A)
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that) (N/A)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable) (N/A - workflow automation only)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

This intentionally uses `pull_request_target` plus a draft check so the prompt only appears on non-draft PRs and when a draft transitions to ready for review. The workflow derives integration metadata directly from PR file paths instead of requiring extra issue-template fields.