### PR TITLE
Ensure SQLite Web always pulls latest image

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResourceBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResourceBuilderExtensions.cs
@@ -80,6 +80,7 @@ public static class SqliteResourceBuilderExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(resource)
                                 .WithImage(SqliteContainerImageTags.SqliteWebImage, SqliteContainerImageTags.SqliteWebTag)
                                 .WithImageRegistry(SqliteContainerImageTags.SqliteWebRegistry)
+                                .WithImagePullPolicy(ImagePullPolicy.Always)
                                 .WithHttpEndpoint(targetPort: 8080, name: "http")
                                 .WithArgs(builder.Resource.DatabaseFileName)
                                 .WithBindMount(builder.Resource.DatabasePath, "/data")

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AddSqliteTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AddSqliteTests.cs
@@ -122,9 +122,13 @@ public class AddSqliteTests
         Assert.Equal(SqliteContainerImageTags.SqliteWebTag, imageAnnotation.Tag);
         Assert.Equal(SqliteContainerImageTags.SqliteWebRegistry, imageAnnotation.Registry);
 
-        var env = await sqliteWeb.GetArgumentListAsync();
-        var envVar = Assert.Single(env);
-        Assert.Equal(sqlite.Resource.DatabaseFileName, envVar);
+        Assert.True(sqliteWeb.TryGetAnnotationsOfType<ContainerImagePullPolicyAnnotation>(out var imagePullPolicyAnnotations));
+        var imagePullPolicyAnnotation = Assert.Single(imagePullPolicyAnnotations);
+        Assert.Equal(ImagePullPolicy.Always, imagePullPolicyAnnotation.ImagePullPolicy);
+
+        var args = await sqliteWeb.GetArgumentListAsync();
+        var databaseFileName = Assert.Single(args);
+        Assert.Equal(sqlite.Resource.DatabaseFileName, databaseFileName);
 
         Assert.True(sqliteWeb.TryGetAnnotationsOfType<ContainerMountAnnotation>(out var bindMountAnnotations));
         var bindMountAnnotation = Assert.Single(bindMountAnnotations);

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AppHostTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AppHostTests.cs
@@ -25,6 +25,19 @@ public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit
     }
 
     [Fact]
+    public async Task SqliteWebResourceStarts()
+    {
+        var resourceName = "sqlite-sqliteweb";
+        await fixture.ResourceNotificationService.WaitForResourceHealthyAsync(resourceName).WaitAsync(TimeSpan.FromMinutes(5));
+        var httpClient = fixture.CreateHttpClient(resourceName, endpointName: "http");
+
+        var response = await httpClient.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("SQLite Web", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task ApiServiceCreateTestItemWithSqliteClient()
     {
         var resourceName = "api";


### PR DESCRIPTION
## Summary

- always pull the SQLite Web container image before starting the resource
- verify the pull policy in the SQLite resource model tests
- verify the SQLite Web resource becomes healthy and serves its UI

## Root cause

The SQLite integration has to use `ghcr.io/coleifer/sqlite-web:latest` because the image does not publish versioned tags. The resource currently uses the container runtime's default pull policy, which can indefinitely reuse a cached `latest` image.

Older cached images can have a different startup contract from the current image. In particular, an image without an entrypoint receives the database filename from Aspire as its command and fails with `exec: "db.sqlite": executable file not found in $PATH`.

Using `ImagePullPolicy.Always` keeps the mutable image tag and its startup contract in sync for every `WithSqliteWeb()` consumer.

## Validation

```text
dotnet test tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests.csproj --no-restore -- --filter-not-class CommunityToolkit.Aspire.Hosting.Sqlite.Tests.TypeScriptAppHostTests --output Normal

Passed: 17
Failed: 0
```

The TypeScript AppHost test was excluded locally because the installed Aspire CLI does not provide the repository's expected `aspire restore` command. It remains covered by CI.
