### PR TITLE
fix(deps): bump System.Security.Cryptography.Xml 8.0.3 → 8.0.4 to clear NU1903 CVE advisories

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -151,7 +151,7 @@
   <ItemGroup Label="Overrides">
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.14" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <!-- Override to address https://github.com/advisories/GHSA-hv8m-jj95-wg3x -->
     <PackageVersion Include="MessagePack" Version="2.5.301" />
     <!-- Override to address https://github.com/advisories/GHSA-pggp-6c3x-2xmx -->


### PR DESCRIPTION
## Motivation

`Directory.Packages.props` currently pins `System.Security.Cryptography.Xml` at `8.0.3`, which has six published high-severity advisories (`GHSA-23rf-6693-g89p`, `GHSA-8q5v-6pqq-x66h`, `GHSA-cvvh-rhrc-wg4q`, `GHSA-g8r8-53c2-pm3f`, `GHSA-mmjf-rqrv-855v`, and one more). With `<NuGetAudit>true` and `<TreatWarningsAsErrors>true` enabled repo-wide, these become `NU1903` build errors on every whole-solution CI job.

**Every open PR that touches anything is currently failing on this,** including Dependabot bumps (#1476, #1477, #1478) that don't touch PowerShell at all.

## Fix

Bump to `8.0.4` — Microsoft's CVE patch release, still `net8.0`-compatible.

## Verification

- `dotnet restore CommunityToolkit.Aspire.slnx` — 0 errors, 0 NU1903
- `dotnet build src/…/PowerShell/…csproj` — succeeds
- `dotnet build src/…/Kind/…csproj` — succeeds
- `dotnet test tests/…/Kind.Tests/…csproj` — 149/149 pass (spot check for no regression)

## Scope

`Directory.Packages.props` — single line. Nothing else touched.