### PR TITLE
Add SurrealDb namespace readiness diagnostics for hang investigations

### DIFF
--- a/examples/surrealdb/CommunityToolkit.Aspire.Hosting.SurrealDb.AppHost/Program.cs
+++ b/examples/surrealdb/CommunityToolkit.Aspire.Hosting.SurrealDb.AppHost/Program.cs
@@ -4,18 +4,9 @@ using Microsoft.Extensions.Logging;
 var builder = DistributedApplication.CreateBuilder(args);
 
 bool strictMode = false;
-bool enableSurrealTraceLogging = string.Equals(
-    Environment.GetEnvironmentVariable("ASPIRE_SURREAL_TRACE_FOR_TESTS"),
-    "1",
-    StringComparison.Ordinal);
 
-var surrealBuilder = builder.AddSurrealServer("surreal");
-if (enableSurrealTraceLogging)
-{
-    surrealBuilder = surrealBuilder.WithLogLevel(LogLevel.Trace);
-}
-
-var db = surrealBuilder
+var db = builder.AddSurrealServer("surreal")
+    .WithLogLevel(LogLevel.Trace)
     .WithSurrealist()
     .AddNamespace("ns")
     .AddDatabase("db");

--- a/examples/surrealdb/CommunityToolkit.Aspire.Hosting.SurrealDb.AppHost/Program.cs
+++ b/examples/surrealdb/CommunityToolkit.Aspire.Hosting.SurrealDb.AppHost/Program.cs
@@ -1,10 +1,12 @@
 using Projects;
+using Microsoft.Extensions.Logging;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
 bool strictMode = false;
 
 var db = builder.AddSurrealServer("surreal")
+    .WithLogLevel(LogLevel.Trace)
     .WithSurrealist()
     .AddNamespace("ns")
     .AddDatabase("db");

--- a/examples/surrealdb/CommunityToolkit.Aspire.Hosting.SurrealDb.AppHost/Program.cs
+++ b/examples/surrealdb/CommunityToolkit.Aspire.Hosting.SurrealDb.AppHost/Program.cs
@@ -4,9 +4,18 @@ using Microsoft.Extensions.Logging;
 var builder = DistributedApplication.CreateBuilder(args);
 
 bool strictMode = false;
+bool enableSurrealTraceLogging = string.Equals(
+    Environment.GetEnvironmentVariable("ASPIRE_SURREAL_TRACE_FOR_TESTS"),
+    "1",
+    StringComparison.Ordinal);
 
-var db = builder.AddSurrealServer("surreal")
-    .WithLogLevel(LogLevel.Trace)
+var surrealBuilder = builder.AddSurrealServer("surreal");
+if (enableSurrealTraceLogging)
+{
+    surrealBuilder = surrealBuilder.WithLogLevel(LogLevel.Trace);
+}
+
+var db = surrealBuilder
     .WithSurrealist()
     .AddNamespace("ns")
     .AddDatabase("db");

--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
@@ -676,6 +676,7 @@ public static class SurrealDbBuilderExtensions
     )
     {
         logger.LogDebug("Ensuring namespace '{NamespaceName}' exists", namespaceResource.NamespaceName);
+        cancellationToken.ThrowIfCancellationRequested();
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -685,6 +686,10 @@ public static class SurrealDbBuilderExtensions
                 await surrealClient.Use(namespaceResource.NamespaceName, null!, cancellationToken).ConfigureAwait(false);
                 return;
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 logger.LogDebug(e, "Namespace '{NamespaceName}' is not available yet", namespaceResource.NamespaceName);
@@ -692,7 +697,7 @@ public static class SurrealDbBuilderExtensions
             }
         }
 
-        throw new DistributedApplicationException($"Namespace '{namespaceResource.Name}' was not created successfully.");
+        throw new DistributedApplicationException($"Namespace '{namespaceResource.NamespaceName}' (resource '{namespaceResource.Name}') was not created successfully.");
     }
 
     private static async Task CreateDatabaseAsync(

--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
@@ -121,27 +121,6 @@ public static class SurrealDbBuilderExtensions
                 await CreateNamespaceAsync(surrealClient, surrealDbNamespace, services, ct)
                     .ConfigureAwait(false);
 
-                // 💡 Wait until the Namespace is really created?!
-                bool nsCreationValidated = false;
-                while (!ct.IsCancellationRequested)
-                {
-                    try
-                    {
-                        await surrealClient.Use(surrealDbNamespace.NamespaceName, null!, ct).ConfigureAwait(false);
-                        nsCreationValidated = true;
-                        break;
-                    }
-                    catch
-                    {
-                        await Task.Delay(200, ct).ConfigureAwait(false);
-                    }
-                }
-
-                if (!nsCreationValidated)
-                {
-                    throw new DistributedApplicationException($"Namespace '{surrealDbNamespace.Name}' was not created successfully.");
-                }
-
                 foreach (var dbResourceName in surrealDbNamespace.Databases.Keys)
                 {
                     if (builder.Resources.FirstOrDefault(n =>
@@ -685,6 +664,35 @@ public static class SurrealDbBuilderExtensions
         {
             logger.LogError(e, "Failed to create namespace '{NamespaceName}'", namespaceResource.NamespaceName);
         }
+
+        await EnsureNamespaceExists(surrealClient, namespaceResource, logger, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task EnsureNamespaceExists(
+        SurrealDbClient surrealClient,
+        SurrealDbNamespaceResource namespaceResource,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        logger.LogDebug("Ensuring namespace '{NamespaceName}' exists", namespaceResource.NamespaceName);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                logger.LogDebug("Testing namespace '{NamespaceName}' is available", namespaceResource.NamespaceName);
+                await surrealClient.Use(namespaceResource.NamespaceName, null!, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (Exception e)
+            {
+                logger.LogDebug(e, "Namespace '{NamespaceName}' is not available yet", namespaceResource.NamespaceName);
+                await Task.Delay(200, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        throw new DistributedApplicationException($"Namespace '{namespaceResource.Name}' was not created successfully.");
     }
 
     private static async Task CreateDatabaseAsync(

--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
@@ -645,17 +645,23 @@ public static class SurrealDbBuilderExtensions
     )
     {
         var scriptAnnotation = namespaceResource.Annotations.OfType<SurrealDbCreateNamespaceScriptAnnotation>().LastOrDefault();
+        string query = scriptAnnotation?.Script ?? $"DEFINE NAMESPACE IF NOT EXISTS `{namespaceResource.NamespaceName}`;";
 
         var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(namespaceResource.Parent);
         logger.LogDebug("Creating namespace '{NamespaceName}'", namespaceResource.NamespaceName);
+        logger.LogTrace("Namespace creation query for '{NamespaceName}': {Query}", namespaceResource.NamespaceName, query);
 
         try
         {
             var response = await surrealClient.RawQuery(
-                scriptAnnotation?.Script ?? $"DEFINE NAMESPACE IF NOT EXISTS `{namespaceResource.NamespaceName}`;",
+                query,
                 cancellationToken: cancellationToken
             ).ConfigureAwait(false);
 
+            logger.LogTrace(
+                "Namespace creation response for '{NamespaceName}': {Response}",
+                namespaceResource.NamespaceName,
+                JsonSerializer.Serialize(response));
             response.EnsureAllOks();
 
             logger.LogDebug("Namespace '{NamespaceName}' created successfully", namespaceResource.NamespaceName);

--- a/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AppHostTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AppHostTests.cs
@@ -7,24 +7,8 @@ using System.Net.Http.Json;
 
 namespace CommunityToolkit.Aspire.Hosting.SurrealDb.Tests;
 
-public class AppHostTraceSurrealFixture : AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost>
-{
-    private readonly string? previousTraceSetting = Environment.GetEnvironmentVariable("ASPIRE_SURREAL_TRACE_FOR_TESTS");
-
-    public AppHostTraceSurrealFixture()
-    {
-        Environment.SetEnvironmentVariable("ASPIRE_SURREAL_TRACE_FOR_TESTS", "1");
-    }
-
-    public override async ValueTask DisposeAsync()
-    {
-        Environment.SetEnvironmentVariable("ASPIRE_SURREAL_TRACE_FOR_TESTS", previousTraceSetting);
-        await base.DisposeAsync();
-    }
-}
-
 [RequiresDocker]
-public class AppHostTests(AppHostTraceSurrealFixture fixture) : IClassFixture<AppHostTraceSurrealFixture>
+public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost> fixture) : IClassFixture<AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost>>
 {
     [Fact]
     public async Task SurrealResourceStartsAndRespondsOk()

--- a/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AppHostTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AppHostTests.cs
@@ -7,8 +7,24 @@ using System.Net.Http.Json;
 
 namespace CommunityToolkit.Aspire.Hosting.SurrealDb.Tests;
 
+public class AppHostTraceSurrealFixture : AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost>
+{
+    private readonly string? previousTraceSetting = Environment.GetEnvironmentVariable("ASPIRE_SURREAL_TRACE_FOR_TESTS");
+
+    public AppHostTraceSurrealFixture()
+    {
+        Environment.SetEnvironmentVariable("ASPIRE_SURREAL_TRACE_FOR_TESTS", "1");
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("ASPIRE_SURREAL_TRACE_FOR_TESTS", previousTraceSetting);
+        await base.DisposeAsync();
+    }
+}
+
 [RequiresDocker]
-public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost> fixture) : IClassFixture<AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost>>
+public class AppHostTests(AppHostTraceSurrealFixture fixture) : IClassFixture<AppHostTraceSurrealFixture>
 {
     [Fact]
     public async Task SurrealResourceStartsAndRespondsOk()

--- a/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AppHostTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AppHostTests.cs
@@ -8,50 +8,83 @@ using System.Net.Http.Json;
 namespace CommunityToolkit.Aspire.Hosting.SurrealDb.Tests;
 
 [RequiresDocker]
-public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost> fixture) : IClassFixture<AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost>>
+public class AppHostTests
 {
-    [Fact]
-    public async Task SurrealResourceStartsAndRespondsOk()
+    private const int RepeatCount = 100;
+
+    public static TheoryData<int> Attempts
+    {
+        get
+        {
+            TheoryData<int> attempts = [];
+
+            for (int attempt = 1; attempt <= RepeatCount; attempt++)
+            {
+                attempts.Add(attempt);
+            }
+
+            return attempts;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Attempts))]
+    public async Task SurrealDbAppHostRepeatsUntilFailure(int attempt)
+    {
+        try
+        {
+            await using AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost> fixture = new();
+            await fixture.InitializeAsync();
+
+            await AssertSurrealResourceStartsAndRespondsOk(fixture);
+            await AssertApiServiceStartsAndRespondsOk(fixture);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"SurrealDb AppHost failed on attempt {attempt} of {RepeatCount}.", ex);
+        }
+    }
+
+    private static async Task AssertSurrealResourceStartsAndRespondsOk(AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost> fixture)
     {
         const string resourceName = "surreal";
         var evt = await fixture.ResourceNotificationService.WaitForResourceHealthyAsync(resourceName).WaitAsync(TimeSpan.FromMinutes(1));
 
         Assert.Equal(KnownResourceStates.Running, evt.Snapshot.State);
 
-        var tcpUri = fixture.GetEndpoint(resourceName, "tcp");
-        var baseUri = new Uri(tcpUri.AbsoluteUri.Replace("tcp://", "http://"));
-        var handler = new HttpClientHandler
+        Uri tcpUri = fixture.GetEndpoint(resourceName, "tcp");
+        Uri baseUri = new(tcpUri.AbsoluteUri.Replace("tcp://", "http://"));
+        HttpClientHandler handler = new()
         {
             AllowAutoRedirect = false
         };
-        var httpClient = new HttpClient(handler)
+        HttpClient httpClient = new(handler)
         {
             BaseAddress = baseUri
         };
 
-        var response = await httpClient.GetAsync("/");
+        HttpResponseMessage response = await httpClient.GetAsync("/");
 
         Assert.Equal(HttpStatusCode.RedirectKeepVerb, response.StatusCode);
         Assert.Equal("https://surrealdb.com/surrealist", response.Headers.Location?.AbsoluteUri);
     }
 
-    [Fact]
-    public async Task ApiServiceStartsAndRespondsOk()
+    private static async Task AssertApiServiceStartsAndRespondsOk(AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Hosting_SurrealDb_AppHost> fixture)
     {
         const string resourceName = "apiservice";
         await fixture.ResourceNotificationService.WaitForResourceHealthyAsync(resourceName).WaitAsync(TimeSpan.FromMinutes(1));
-        var httpClient = fixture.CreateHttpClient(resourceName);
+        HttpClient httpClient = fixture.CreateHttpClient(resourceName);
 
-        var initResponse = await httpClient.PostAsync("/init", null);
+        HttpResponseMessage initResponse = await httpClient.PostAsync("/init", null);
         Assert.Equal(HttpStatusCode.OK, initResponse.StatusCode);
-        
-        var todoResponse = await httpClient.GetAsync("/api/todo");
+
+        HttpResponseMessage todoResponse = await httpClient.GetAsync("/api/todo");
         Assert.Equal(HttpStatusCode.OK, todoResponse.StatusCode);
 
-        var weatherForecastResponse = await httpClient.GetAsync("/api/weatherForecast");
+        HttpResponseMessage weatherForecastResponse = await httpClient.GetAsync("/api/weatherForecast");
         Assert.Equal(HttpStatusCode.OK, weatherForecastResponse.StatusCode);
 
-        var data = await weatherForecastResponse.Content.ReadFromJsonAsync<List<object>>();
+        List<object>? data = await weatherForecastResponse.Content.ReadFromJsonAsync<List<object>>();
 
         Assert.NotNull(data);
         Assert.NotEmpty(data);

--- a/tests/CommunityToolkit.Aspire.Testing/AspireIntegrationTest.cs
+++ b/tests/CommunityToolkit.Aspire.Testing/AspireIntegrationTest.cs
@@ -22,7 +22,7 @@ public class AspireIntegrationTestFixture<TEntryPoint>() : DistributedApplicatio
                 if (Environment.GetEnvironmentVariable("RUNNER_DEBUG") is not null && Environment.GetEnvironmentVariable("RUNNER_DEBUG") == "1")
                     builder.SetMinimumLevel(LogLevel.Trace);
                 else
-                    builder.SetMinimumLevel(LogLevel.Information);
+                    builder.SetMinimumLevel(LogLevel.Debug);
             })
             .ConfigureHttpClientDefaults(clientBuilder => clientBuilder.AddStandardResilienceHandler());
 


### PR DESCRIPTION
## Summary
This PR adds targeted diagnostics to the SurrealDb hosting integration to make future startup hangs easier to narrow down.

## Why
A recent CI failure was a startup hang (not a test assertion failure) where resources were healthy but not fully marked ready, which left dependent resources waiting.

Analyzed build:
- https://github.com/CommunityToolkit/Aspire/actions/runs/30697380769/job/91362494030?pr=1475

From the dump/log analysis:
- `apiservice` was waiting on `surreal` readiness.
- `surreal` stayed healthy/running but its readiness pipeline was blocked in namespace/database initialization (`Use(...)` path), so it never reached ready.

## What changed
- Extracted namespace availability polling into `EnsureNamespaceExists`.
- Added explicit debug logging before each namespace availability probe (`Use(...)`) to show we are actively testing namespace readiness.
- Stopped silently swallowing probe exceptions; retry-loop exceptions are now written to debug logs.
- Raised default logging level for `AspireIntegrationTestFixture` tests to `Debug` (while still using `Trace` when `RUNNER_DEBUG=1`) so CI/test output captures richer diagnostics for future hangs.

## Intent
This does **not** claim to fully fix every hang scenario. It adds additional logging and structure to reduce ambiguity and accelerate root-cause analysis when hangs recur.