### PR TITLE
Fix integration codeowner workflow failing on github-script v9

### DIFF
--- a/.github/workflows/integration-codeowner.yml
+++ b/.github/workflows/integration-codeowner.yml
@@ -19,8 +19,6 @@ jobs:
         uses: actions/github-script@v9.0.0
         with:
           script: |
-            const core = require('@actions/core');
-
             const pr = context.payload.pull_request;
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
@@ -101,8 +99,6 @@ jobs:
         uses: actions/github-script@v9.0.0
         with:
           script: |
-            const core = require('@actions/core');
-
             const comment = context.payload.comment;
             const command = comment.body.trim();
             const accepted = command === '/codeowner-accept';


### PR DESCRIPTION
## Summary
- Remove redundant `require('@actions/core')` declarations from `.github/workflows/integration-codeowner.yml`
- Keep existing `core.setOutput(...)` usage unchanged
- Fix `SyntaxError: Identifier 'core' has already been declared` in `actions/github-script@v9` steps

## Why this PR still shows a failing check
`Integration code owner automation` is triggered by `pull_request_target`.

For `pull_request_target` events, GitHub evaluates workflow files from the base branch (`main`), not from the PR head branch. That means PR #1499 still executes the currently broken workflow definition on `main`, so `prompt-for-codeowner` continues to fail on this PR even though the fix is present in the PR branch.

After this PR merges, the fixed workflow will exist on `main`, and subsequent `pull_request_target` runs will use the corrected version.

## Root cause
The workflow was introduced with `actions/github-script@v9` scripts that redeclared `core`:

```js
const core = require('@actions/core');
```

In `github-script@v9`, `core` is already provided in the script context, so redeclaration throws and hard-fails the job.