### PR TITLE
Upgrade Aspire to 13.4.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <Nullable>enable</Nullable>
 
     <AspireMajorVersion>13</AspireMajorVersion>
+    <!-- When updating AspireVersion, also update the "aspire.version" field in global.json and the "sdk.version" in all examples/**/aspire.config.json files -->
     <AspireVersion>$(AspireMajorVersion).4.6</AspireVersion>
     <AspirePreviewSuffix>-preview.1.26305.13</AspirePreviewSuffix> <!-- Used for Aspire packages that still only ship as prerelease packages on nuget.org. -->
     <AspNetCoreVersion>9.0.0</AspNetCoreVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <Nullable>enable</Nullable>
 
     <AspireMajorVersion>13</AspireMajorVersion>
-    <AspireVersion>$(AspireMajorVersion).4.3</AspireVersion>
+    <AspireVersion>$(AspireMajorVersion).4.6</AspireVersion>
     <AspirePreviewSuffix>-preview.1.26305.13</AspirePreviewSuffix> <!-- Used for Aspire packages that still only ship as prerelease packages on nuget.org. -->
     <AspNetCoreVersion>9.0.0</AspNetCoreVersion>
     <DotNetExtensionsVersion>10.0.8</DotNetExtensionsVersion>

--- a/examples/activemq/CommunityToolkit.Aspire.Hosting.ActiveMQ.AppHost.TypeScript/aspire.config.json
+++ b/examples/activemq/CommunityToolkit.Aspire.Hosting.ActiveMQ.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/adminer/CommunityToolkit.Aspire.Hosting.Adminer.AppHost.TypeScript/aspire.config.json
+++ b/examples/adminer/CommunityToolkit.Aspire.Hosting.Adminer.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/azure-ext/CommunityToolkit.Aspire.Azure.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/azure-ext/CommunityToolkit.Aspire.Azure.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/bun/CommunityToolkit.Aspire.Hosting.Bun.AppHost.TypeScript/aspire.config.json
+++ b/examples/bun/CommunityToolkit.Aspire.Hosting.Bun.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "channel": "stable",
   "profiles": {

--- a/examples/dapr/CommunityToolkit.Aspire.Hosting.Azure.Dapr.AppHost.TypeScript/aspire.config.json
+++ b/examples/dapr/CommunityToolkit.Aspire.Hosting.Azure.Dapr.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/dapr/CommunityToolkit.Aspire.Hosting.Dapr.AppHost.TypeScript/aspire.config.json
+++ b/examples/dapr/CommunityToolkit.Aspire.Hosting.Dapr.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/data-api-builder/CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder.AppHost.TypeScript/aspire.config.json
+++ b/examples/data-api-builder/CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/dbgate/CommunityToolkit.Aspire.Hosting.DbGate.AppHost.TypeScript/aspire.config.json
+++ b/examples/dbgate/CommunityToolkit.Aspire.Hosting.DbGate.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/dbx/CommunityToolkit.Aspire.Hosting.Dbx.AppHost.TypeScript/aspire.config.json
+++ b/examples/dbx/CommunityToolkit.Aspire.Hosting.Dbx.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/deno/CommunityToolkit.Aspire.Hosting.Deno.AppHost.TypeScript/aspire.config.json
+++ b/examples/deno/CommunityToolkit.Aspire.Hosting.Deno.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/duckdb/CommunityToolkit.Aspire.DuckDB.AppHost.TypeScript/aspire.config.json
+++ b/examples/duckdb/CommunityToolkit.Aspire.DuckDB.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/elasticsearch-ext/CommunityToolkit.Aspire.Hosting.Elasticsearch.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/elasticsearch-ext/CommunityToolkit.Aspire.Hosting.Elasticsearch.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/flagd/CommunityToolkit.Aspire.Hosting.Flagd.AppHost.TypeScript/aspire.config.json
+++ b/examples/flagd/CommunityToolkit.Aspire.Hosting.Flagd.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/flyway/CommunityToolkit.Aspire.Hosting.Flyway.AppHost.TypeScript/aspire.config.json
+++ b/examples/flyway/CommunityToolkit.Aspire.Hosting.Flyway.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/goff/CommunityToolkit.Aspire.Hosting.GoFeatureFlag.AppHost.TypeScript/aspire.config.json
+++ b/examples/goff/CommunityToolkit.Aspire.Hosting.GoFeatureFlag.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/java/CommunityToolkit.Aspire.Hosting.Java.AppHost.TypeScript/aspire.config.json
+++ b/examples/java/CommunityToolkit.Aspire.Hosting.Java.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/javascript-ext/CommunityToolkit.Aspire.Hosting.JavaScript.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/javascript-ext/CommunityToolkit.Aspire.Hosting.JavaScript.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/k3s/CommunityToolkit.Aspire.Hosting.K3s.AppHost.Go/aspire.config.json
+++ b/examples/k3s/CommunityToolkit.Aspire.Hosting.K3s.AppHost.Go/aspire.config.json
@@ -7,7 +7,7 @@
     "go": "true"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "packages": {
     "CommunityToolkit.Aspire.Hosting.K3s": "../../../src/CommunityToolkit.Aspire.Hosting.K3s/CommunityToolkit.Aspire.Hosting.K3s.csproj"

--- a/examples/k3s/CommunityToolkit.Aspire.Hosting.K3s.AppHost.TypeScript/aspire.config.json
+++ b/examples/k3s/CommunityToolkit.Aspire.Hosting.K3s.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "packages": {
     "CommunityToolkit.Aspire.Hosting.K3s": "../../../src/CommunityToolkit.Aspire.Hosting.K3s/CommunityToolkit.Aspire.Hosting.K3s.csproj"

--- a/examples/k6/CommunityToolkit.Aspire.Hosting.k6.AppHost.TypeScript/aspire.config.json
+++ b/examples/k6/CommunityToolkit.Aspire.Hosting.k6.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/keycloak-postgres/CommunityToolkit.Aspire.Hosting.Keycloak.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/keycloak-postgres/CommunityToolkit.Aspire.Hosting.Keycloak.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/kurrentdb/CommunityToolkit.Aspire.Hosting.KurrentDB.AppHost.TypeScript/aspire.config.json
+++ b/examples/kurrentdb/CommunityToolkit.Aspire.Hosting.KurrentDB.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/lavinmq/CommunityToolkit.Aspire.Hosting.LavinMQ.AppHost.TypeScript/aspire.config.json
+++ b/examples/lavinmq/CommunityToolkit.Aspire.Hosting.LavinMQ.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/listmonk/CommunityToolkit.Aspire.Hosting.Listmonk.AppHost.TypeScript/aspire.config.json
+++ b/examples/listmonk/CommunityToolkit.Aspire.Hosting.Listmonk.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/logto/CommunityToolkit.Aspire.Hosting.Logto.AppHost.TypeScript/aspire.config.json
+++ b/examples/logto/CommunityToolkit.Aspire.Hosting.Logto.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/mailpit/CommunityToolkit.Aspire.Hosting.MailPit.AppHost.TypeScript/aspire.config.json
+++ b/examples/mailpit/CommunityToolkit.Aspire.Hosting.MailPit.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/mcp-inspector/CommunityToolkit.Aspire.Hosting.McpInspector.AppHost.TypeScript/aspire.config.json
+++ b/examples/mcp-inspector/CommunityToolkit.Aspire.Hosting.McpInspector.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/meilisearch/CommunityToolkit.Aspire.Hosting.Meilisearch.AppHost.TypeScript/aspire.config.json
+++ b/examples/meilisearch/CommunityToolkit.Aspire.Hosting.Meilisearch.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/minio/CommunityToolkit.Aspire.Hosting.Minio.AppHost.TypeScript/aspire.config.json
+++ b/examples/minio/CommunityToolkit.Aspire.Hosting.Minio.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/mongodb-ext/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/mongodb-ext/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/mysql-ext/CommunityToolkit.Aspire.Hosting.MySql.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/mysql-ext/CommunityToolkit.Aspire.Hosting.MySql.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/ngrok/CommunityToolkit.Aspire.Hosting.Ngrok.AppHost.TypeScript/aspire.config.json
+++ b/examples/ngrok/CommunityToolkit.Aspire.Hosting.Ngrok.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/ollama/CommunityToolkit.Aspire.Hosting.Ollama.AppHost.TypeScript/aspire.config.json
+++ b/examples/ollama/CommunityToolkit.Aspire.Hosting.Ollama.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/opentelemetry-collector/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.AppHost.TypeScript/aspire.config.json
+++ b/examples/opentelemetry-collector/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/papercut/CommunityToolkit.Aspire.Hosting.PapercutSmtp.AppHost.TypeScript/aspire.config.json
+++ b/examples/papercut/CommunityToolkit.Aspire.Hosting.PapercutSmtp.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/perl/CpanmApiIntegration.AppHost.TypeScript/aspire.config.json
+++ b/examples/perl/CpanmApiIntegration.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/postgres-ext/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/postgres-ext/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/powershell/CommunityToolkit.Aspire.PowerShell.AppHost.TypeScript/aspire.config.json
+++ b/examples/powershell/CommunityToolkit.Aspire.PowerShell.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/python/CommunityToolkit.Aspire.Hosting.Python.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/python/CommunityToolkit.Aspire.Hosting.Python.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/ravendb/CommunityToolkit.Aspire.Hosting.RavenDB.AppHost.TypeScript/aspire.config.json
+++ b/examples/ravendb/CommunityToolkit.Aspire.Hosting.RavenDB.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/redis-ext/CommunityToolkit.Aspire.Hosting.Redis.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/redis-ext/CommunityToolkit.Aspire.Hosting.Redis.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/rust/CommunityToolkit.Aspire.Hosting.Rust.AppHost.TypeScript/aspire.config.json
+++ b/examples/rust/CommunityToolkit.Aspire.Hosting.Rust.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/rustfs/CommunityToolkit.Aspire.Hosting.RustFs.AppHost.TypeScript/aspire.config.json
+++ b/examples/rustfs/CommunityToolkit.Aspire.Hosting.RustFs.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/seaweedfs/SeaweedFS.AppHost.TypeScript/aspire.config.json
+++ b/examples/seaweedfs/SeaweedFS.AppHost.TypeScript/aspire.config.json
@@ -1,10 +1,10 @@
-﻿{
+{
   "appHost": {
     "path": "apphost.mts",
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "http": {

--- a/examples/sftp/CommunityToolkit.Aspire.Hosting.Sftp.AppHost.TypeScript/aspire.config.json
+++ b/examples/sftp/CommunityToolkit.Aspire.Hosting.Sftp.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/solr/CommunityToolkit.Aspire.Hosting.Solr.AppHost.TypeScript/aspire.config.json
+++ b/examples/solr/CommunityToolkit.Aspire.Hosting.Solr.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/sql-database-projects/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.AppHost.TypeScript/aspire.config.json
+++ b/examples/sql-database-projects/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/sqlite/CommunityToolkit.Aspire.Hosting.Sqlite.AppHost.TypeScript/aspire.config.json
+++ b/examples/sqlite/CommunityToolkit.Aspire.Hosting.Sqlite.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/sqlserver-ext/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.AppHost.TypeScript/aspire.config.json
+++ b/examples/sqlserver-ext/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/squad/CommunityToolkit.Aspire.Hosting.Squad.AppHost.TypeScript/aspire.config.json
+++ b/examples/squad/CommunityToolkit.Aspire.Hosting.Squad.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "channel": "stable",
   "profiles": {

--- a/examples/stripe/CommunityToolkit.Aspire.Hosting.Stripe.AppHost.TypeScript/aspire.config.json
+++ b/examples/stripe/CommunityToolkit.Aspire.Hosting.Stripe.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/surrealdb/CommunityToolkit.Aspire.Hosting.SurrealDb.AppHost.TypeScript/aspire.config.json
+++ b/examples/surrealdb/CommunityToolkit.Aspire.Hosting.SurrealDb.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/umami/CommunityToolkit.Aspire.Hosting.Umami.AppHost.TypeScript/aspire.config.json
+++ b/examples/umami/CommunityToolkit.Aspire.Hosting.Umami.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/examples/zitadel/CommunityToolkit.Aspire.Hosting.Zitadel.AppHost.TypeScript/aspire.config.json
+++ b/examples/zitadel/CommunityToolkit.Aspire.Hosting.Zitadel.AppHost.TypeScript/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.3"
+    "version": "13.4.6"
   },
   "profiles": {
     "https": {

--- a/global.json
+++ b/global.json
@@ -2,6 +2,9 @@
   "sdk": {
     "allowPrerelease": true
   },
+  "aspire": {
+    "version": "13.4.6"
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }


### PR DESCRIPTION
Bumps `AspireVersion` from `13.4.3` to `13.4.6` in `Directory.Build.props`.

13.4.6 includes a fix for DCP requests that could fail permanently when the connection dropped mid-request -- the error was surfaced directly instead of being retried. Reconnection is now attempted as part of the DCP request retry path, so transient disconnections recover automatically. This is expected to reduce flakiness around `System.IO.InvalidDataException : Service X should have valid address at this point` errors in integration tests.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Contains **NO** breaking changes

## Other information

Aspire DCP fix: dotnet/aspire#18096 (@karolz-ms)