### PR TITLE
Fix SurrealDB server readiness: add health check, remove provisioning retry loop

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
@@ -78,6 +78,14 @@ public static class SurrealDbBuilderExtensions
 
         var surrealServer = new SurrealDbServerResource(name, userName?.Resource, passwordParameter);
 
+        string serverHealthCheckKey = $"{name}_server_check";
+        builder.Services.AddHealthChecks().Add(new HealthCheckRegistration(
+            name: serverHealthCheckKey,
+            sp => new SurrealDbServerHealthCheck(surrealServer, sp.GetRequiredService<ILogger<SurrealDbServerHealthCheck>>()),
+            failureStatus: null,
+            tags: null
+        ));
+
         return builder.AddResource(surrealServer)
                       .WithEndpoint(port: port, targetPort: SurrealDbPort, name: SurrealDbServerResource.PrimaryEndpointName)
                       .WithImage(SurrealDbContainerImageTags.Image, imageTag)
@@ -89,6 +97,7 @@ public static class SurrealDbBuilderExtensions
                       })
                       .WithEntrypoint("/surreal")
                       .WithArgs([.. args])
+                      .WithHealthCheck(serverHealthCheckKey)
                       .OnResourceReady(async (_, @event, ct) =>
                       {
                           var connectionString = await surrealServer.GetConnectionStringAsync(ct).ConfigureAwait(false);
@@ -121,26 +130,7 @@ public static class SurrealDbBuilderExtensions
                 await CreateNamespaceAsync(surrealClient, surrealDbNamespace, services, ct)
                     .ConfigureAwait(false);
 
-                // 💡 Wait until the Namespace is really created?!
-                bool nsCreationValidated = false;
-                while (!ct.IsCancellationRequested)
-                {
-                    try
-                    {
-                        await surrealClient.Use(surrealDbNamespace.NamespaceName, null!, ct).ConfigureAwait(false);
-                        nsCreationValidated = true;
-                        break;
-                    }
-                    catch
-                    {
-                        await Task.Delay(200, ct).ConfigureAwait(false);
-                    }
-                }
-
-                if (!nsCreationValidated)
-                {
-                    throw new DistributedApplicationException($"Namespace '{surrealDbNamespace.Name}' was not created successfully.");
-                }
+                await surrealClient.Use(surrealDbNamespace.NamespaceName, null!, ct).ConfigureAwait(false);
 
                 foreach (var dbResourceName in surrealDbNamespace.Databases.Keys)
                 {
@@ -681,9 +671,11 @@ public static class SurrealDbBuilderExtensions
 
             logger.LogDebug("Namespace '{NamespaceName}' created successfully", namespaceResource.NamespaceName);
         }
-        catch (Exception e)
+        catch (Exception e) when (e is not OperationCanceledException)
         {
-            logger.LogError(e, "Failed to create namespace '{NamespaceName}'", namespaceResource.NamespaceName);
+            logger.LogError(e, "Failed to create namespace '{NamespaceName}' on resource '{ResourceName}'", namespaceResource.NamespaceName, namespaceResource.Parent.Name);
+            throw new DistributedApplicationException(
+                $"Failed to create namespace '{namespaceResource.NamespaceName}' on resource '{namespaceResource.Parent.Name}': {e.Message}", e);
         }
     }
 
@@ -710,9 +702,38 @@ public static class SurrealDbBuilderExtensions
 
             logger.LogDebug("Database '{DatabaseName}' created successfully", databaseResource.DatabaseName);
         }
-        catch (Exception e)
+        catch (Exception e) when (e is not OperationCanceledException)
         {
-            logger.LogError(e, "Failed to create database '{DatabaseName}'", databaseResource.DatabaseName);
+            logger.LogError(e, "Failed to create database '{DatabaseName}' in namespace '{NamespaceName}' on resource '{ResourceName}'", databaseResource.DatabaseName, databaseResource.Parent.NamespaceName, databaseResource.Parent.Parent.Name);
+            throw new DistributedApplicationException(
+                $"Failed to create database '{databaseResource.DatabaseName}' in namespace '{databaseResource.Parent.NamespaceName}' on resource '{databaseResource.Parent.Parent.Name}': {e.Message}", e);
+        }
+    }
+
+    private sealed class SurrealDbServerHealthCheck(SurrealDbServerResource server, ILogger<SurrealDbServerHealthCheck> logger) : IHealthCheck
+    {
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var connectionString = await server.ConnectionStringExpression.GetValueAsync(cancellationToken).ConfigureAwait(false)
+                    ?? throw new InvalidOperationException($"Connection string for resource '{server.Name}' is not available.");
+
+                var options = new SurrealDbOptionsBuilder().FromConnectionString(connectionString).Build();
+                await using var client = new SurrealDbClient(options);
+
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+                return await client.Health(cts.Token).ConfigureAwait(false)
+                    ? HealthCheckResult.Healthy()
+                    : new HealthCheckResult(context.Registration.FailureStatus);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "SurrealDB server health check for '{ResourceName}' raised an exception.", server.Name);
+                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            }
         }
     }
 }

--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
@@ -710,34 +710,4 @@ public static class SurrealDbBuilderExtensions
         }
     }
 
-    private sealed class SurrealDbServerHealthCheck(SurrealDbServerResource server, ILogger<SurrealDbServerHealthCheck> logger) : IHealthCheck
-    {
-        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                var connectionString = await server.ConnectionStringExpression.GetValueAsync(cancellationToken).ConfigureAwait(false)
-                    ?? throw new InvalidOperationException($"Connection string for resource '{server.Name}' is not available.");
-
-                var options = new SurrealDbOptionsBuilder().FromConnectionString(connectionString).Build();
-                await using var client = new SurrealDbClient(options);
-
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(TimeSpan.FromSeconds(5));
-
-                return await client.Health(cts.Token).ConfigureAwait(false)
-                    ? HealthCheckResult.Healthy()
-                    : new HealthCheckResult(context.Registration.FailureStatus);
-            }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-            {
-                return new HealthCheckResult(context.Registration.FailureStatus);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "SurrealDB server health check for '{ResourceName}' raised an exception.", server.Name);
-                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
-            }
-        }
-    }
 }

--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
@@ -716,14 +716,14 @@ public static class SurrealDbBuilderExtensions
         {
             try
             {
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(TimeSpan.FromSeconds(5));
-
-                var connectionString = await server.ConnectionStringExpression.GetValueAsync(cts.Token).ConfigureAwait(false)
+                var connectionString = await server.ConnectionStringExpression.GetValueAsync(cancellationToken).ConfigureAwait(false)
                     ?? throw new InvalidOperationException($"Connection string for resource '{server.Name}' is not available.");
 
                 var options = new SurrealDbOptionsBuilder().FromConnectionString(connectionString).Build();
                 await using var client = new SurrealDbClient(options);
+
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(5));
 
                 return await client.Health(cts.Token).ConfigureAwait(false)
                     ? HealthCheckResult.Healthy()

--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbBuilderExtensions.cs
@@ -716,18 +716,22 @@ public static class SurrealDbBuilderExtensions
         {
             try
             {
-                var connectionString = await server.ConnectionStringExpression.GetValueAsync(cancellationToken).ConfigureAwait(false)
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+                var connectionString = await server.ConnectionStringExpression.GetValueAsync(cts.Token).ConfigureAwait(false)
                     ?? throw new InvalidOperationException($"Connection string for resource '{server.Name}' is not available.");
 
                 var options = new SurrealDbOptionsBuilder().FromConnectionString(connectionString).Build();
                 await using var client = new SurrealDbClient(options);
 
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(TimeSpan.FromSeconds(5));
-
                 return await client.Health(cts.Token).ConfigureAwait(false)
                     ? HealthCheckResult.Healthy()
                     : new HealthCheckResult(context.Registration.FailureStatus);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                return new HealthCheckResult(context.Registration.FailureStatus);
             }
             catch (Exception ex)
             {

--- a/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbServerHealthCheck.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbServerHealthCheck.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using SurrealDb.Net;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Performs a health check for a SurrealDB server resource by validating that the server is accepting client traffic.
+/// </summary>
+internal sealed class SurrealDbServerHealthCheck(SurrealDbServerResource server, ILogger<SurrealDbServerHealthCheck> logger) : IHealthCheck
+{
+    /// <inheritdoc />
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var connectionString = await server.ConnectionStringExpression.GetValueAsync(cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Connection string for resource '{server.Name}' is not available.");
+
+            var options = new SurrealDbOptionsBuilder().FromConnectionString(connectionString).Build();
+            await using var client = new SurrealDbClient(options);
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+            return await client.Health(cts.Token).ConfigureAwait(false)
+                ? HealthCheckResult.Healthy()
+                : new HealthCheckResult(context.Registration.FailureStatus);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new HealthCheckResult(context.Registration.FailureStatus);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "SurrealDB server health check for '{ResourceName}' raised an exception.", server.Name);
+            return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+        }
+    }
+}

--- a/src/CommunityToolkit.Aspire.SurrealDb/SurrealDbHealthCheck.cs
+++ b/src/CommunityToolkit.Aspire.SurrealDb/SurrealDbHealthCheck.cs
@@ -23,9 +23,6 @@ internal sealed class SurrealDbHealthCheck(SurrealDbOptions options, ILogger<Sur
             var response = await surrealdbClient.RawQuery("RETURN 1", cancellationToken: cancellationToken).ConfigureAwait(false);
             response.EnsureAllOks();
 
-            logger.LogInformation("SurrealDB health check passed. Response: {Response}", response);
-            logger.LogInformation("SurrealDB health check outcome: {Outcome}", isHealthy ? "Healthy" : "Unhealthy");
-
             return isHealthy
                 ? HealthCheckResult.Healthy()
                 : new HealthCheckResult(context.Registration.FailureStatus);

--- a/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AddSurrealServerTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AddSurrealServerTests.cs
@@ -3,7 +3,9 @@
 
 using Aspire.Hosting;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System.Net.Sockets;
 using CommunityToolkit.Aspire.Testing;
 
@@ -91,6 +93,9 @@ public class AddSurrealServerTests
         var containerResource = Assert.Single(appModel.Resources.OfType<SurrealDbServerResource>());
         var healthCheckAnnotation = Assert.Single(containerResource.Annotations.OfType<HealthCheckAnnotation>());
         Assert.Equal("surreal_server_check", healthCheckAnnotation.Key);
+
+        var registrations = app.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+        Assert.Contains(registrations, registration => registration.Name == "surreal_server_check");
     }
 
     [Fact]

--- a/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AddSurrealServerTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SurrealDb.Tests/AddSurrealServerTests.cs
@@ -78,6 +78,22 @@ public class AddSurrealServerTests
     }
 
     [Fact]
+    public void AddSurrealServerRegistersHealthCheck()
+    {
+        using var appBuilder = TestDistributedApplicationBuilder.Create();
+
+        appBuilder.AddSurrealServer("surreal");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var containerResource = Assert.Single(appModel.Resources.OfType<SurrealDbServerResource>());
+        var healthCheckAnnotation = Assert.Single(containerResource.Annotations.OfType<HealthCheckAnnotation>());
+        Assert.Equal("surreal_server_check", healthCheckAnnotation.Key);
+    }
+
+    [Fact]
     public async Task SurrealServerCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();


### PR DESCRIPTION
Based on analysis from #1497

The `SurrealDbServerResource` had a startup race: `OnResourceReady` fired as soon as the container was running, before SurrealDB was actually accepting WebSocket/RPC traffic. Namespace/database bootstrapping could then fail at the connection level, and the fallback retry loop (`while (!ct.IsCancellationRequested)`) could hang indefinitely until the outer test timeout.

This PR fixes the race cleanly without adding more recovery logic:

**Server health check** -- `AddSurrealServer` now registers a `SurrealDbServerHealthCheck` (via `WithHealthCheck`) that calls `client.Health()` over WebSocket. The check resolves the connection string lazily via `ConnectionStringExpression.GetValueAsync(ct)` on each poll, so no `OnConnectionStringAvailable` plumbing is needed. A 5-second linked `CancellationTokenSource` bounds each probe, since `SurrealDbClient.Health()` has no internal timeout on the WS engine. `OnResourceReady` now only fires after the health check passes, i.e. after the RPC channel is confirmed usable.

**Provisioning fail-fast** -- The open-ended `while (!ct.IsCancellationRequested)` retry loop in `EnsuresNsDbCreated` is removed and replaced with a single `Use()` call. `CreateNamespaceAsync` and `CreateDatabaseAsync` no longer swallow exceptions; failures throw `DistributedApplicationException` immediately with resource name, namespace, and database in the message.

**Log cleanup** -- Two `LogInformation` calls in `SurrealDbHealthCheck` that fired on every poll are removed.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration
  - [ ] Docs are written
  - [ ] Added description of major feature to project description for NuGet package (4000 total character limit, so don't push entire description over that)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

The `SurrealDbServerHealthCheck` private class is self-contained inside `SurrealDbBuilderExtensions` and is not part of the public API. The existing `SurrealDbHealthCheck` (used for database-level health checks) is unchanged except for removal of the noisy info logs.

Docker integration tests (`AppHostTests`) are the authoritative end-to-end validation and require Docker to run.