### PR TITLE
Gate Aspire doctor and failure logs when tests are skipped

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,6 +107,7 @@ jobs:
           dotnet build ${{ github.workspace }}/${{ env.TEST_PROJECT_PATH }} /bl --configuration ${{ env.DOTNET_CONFIGURATION }}
 
       - name: Run tests
+        id: run-tests
         run: >-
           dotnet run
           --project "${{ github.workspace }}/${{ env.TEST_PROJECT_PATH }}"
@@ -150,19 +151,19 @@ jobs:
           path: testresults/**
 
       - name: Upload npm logs if failed
-        if: failure()
+        if: failure() && steps.run-tests.outcome != 'skipped'
         uses: actions/upload-artifact@v7
         with:
           name: npm-logs-${{ matrix.name }}-${{ matrix.os }}
           path: ${{ runner.os == 'Windows' && 'C:\\npm\\cache\\_logs\\**' || '~/.npm/cache/_logs/**' }}
 
       - name: Upload TypeScript app host logs if failed
-        if: failure()
+        if: failure() && steps.run-tests.outcome != 'skipped'
         uses: actions/upload-artifact@v7
         with:
           name: ts-app-host-logs-${{ matrix.name }}-${{ matrix.os }}
           path: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\.aspire\\logs\\**' || '/home/runner/.aspire/logs/**' }}
 
       - name: Aspire doctor
-        if: failure()
+        if: failure() && steps.run-tests.outcome != 'skipped'
         run: aspire doctor


### PR DESCRIPTION
## Summary
- add an explicit id to the `Run tests` step in `.github/workflows/tests.yaml`
- gate failure diagnostics with `steps.run-tests.outcome != 'skipped'`
- prevent `Aspire doctor`, npm log upload, and TypeScript app host log upload from running when tests never started

## Why

This avoids some misleading errors where at first glance you may think that `aspire doctor` caused the CI failure, but it was really just a knock on from the tooling setup failure.

<img width="1372" height="1102" alt="image" src="https://github.com/user-attachments/assets/cdf8e696-c804-4379-a800-a1de8d3667e2" />
