### PR TITLE
Updating dependencies that have CVEs on them

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <AspirePreviewSuffix>-preview.1.26305.13</AspirePreviewSuffix> <!-- Used for Aspire packages that still only ship as prerelease packages on nuget.org. -->
     <AspNetCoreVersion>9.0.0</AspNetCoreVersion>
     <DotNetExtensionsVersion>10.0.8</DotNetExtensionsVersion>
-    <TestContainersVersion>4.8.1</TestContainersVersion>
+    <TestContainersVersion>4.14.0</TestContainersVersion>
     <MEAIVersion>10.6.0</MEAIVersion>
     <ServiceDiscoveryVersion>10.0.0</ServiceDiscoveryVersion>
     <IsPackable>false</IsPackable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -121,7 +121,7 @@
     <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
     <PackageVersion Include="KurrentDB.Client" Version="1.2.0" />
-    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <!-- Testing packages -->

--- a/tests/CommunityToolkit.Aspire.GoFeatureFlag.Tests/GoFeatureFlagContainerFixture.cs
+++ b/tests/CommunityToolkit.Aspire.GoFeatureFlag.Tests/GoFeatureFlagContainerFixture.cs
@@ -28,8 +28,7 @@ public sealed class GoFeatureFlagContainerFixture : IAsyncLifetime
         if (RequiresDockerAttribute.IsSupported)
         {
             var source = Path.GetFullPath("./goff", Directory.GetCurrentDirectory());
-            Container = new ContainerBuilder()
-              .WithImage($"{GoFeatureFlagContainerImageTags.Registry}/{GoFeatureFlagContainerImageTags.Image}:{GoFeatureFlagContainerImageTags.Tag}")
+            Container = new ContainerBuilder($"{GoFeatureFlagContainerImageTags.Registry}/{GoFeatureFlagContainerImageTags.Image}:{GoFeatureFlagContainerImageTags.Tag}")
               .WithPortBinding(1031, true)
               .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPath("/health").ForPort(1031)))
               .WithBindMount(source, "/goff")

--- a/tests/CommunityToolkit.Aspire.Hosting.Kind.Tests/KindImageLoadingTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Kind.Tests/KindImageLoadingTests.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using CommunityToolkit.Aspire.Hosting.Kind;
+using CommunityToolkit.Aspire.Testing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CommunityToolkit.Aspire.Hosting.Kind.Tests;
@@ -204,6 +205,7 @@ public class KindImageLoadingTests
     }
 
     [Fact]
+    [RequiresLinux(Reason = "The current Windows runner for GitHub Actions only has Helm 4.1.4, which is below the Aspire requirement of Helm 4.2.0. This test is skipped on Windows to avoid failures in CI.")]
     public async Task UsesPodmanProviderWhenLoadingImagesWithPodmanRuntime()
     {
         var (fakeRunner, builder) = CreateBuilderWithFakeRunner("ASPIRE_CONTAINER_RUNTIME=podman");

--- a/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/SqlServerContainerFixture.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.Tests/SqlServerContainerFixture.cs
@@ -25,8 +25,7 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
 
     public static async Task<MsSqlContainer> CreateContainerAsync()
     {
-        var container = new MsSqlBuilder()
-            .WithImage($"{Registry}/{Image}:{Tag}")
+        var container = new MsSqlBuilder($"{Registry}/{Image}:{Tag}")
             .Build();
         await container.StartAsync();
 

--- a/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AppHostTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Sqlite.Tests/AppHostTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 
 namespace CommunityToolkit.Aspire.Hosting.Sqlite;
 
+[RequiresDocker]
 public class AppHostTests(AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Sqlite_AppHost> fixture) : IClassFixture<AspireIntegrationTestFixture<Projects.CommunityToolkit_Aspire_Sqlite_AppHost>>
 {
     [Fact]

--- a/tests/CommunityToolkit.Aspire.KurrentDB.Tests/KurrentDBContainerFixture.cs
+++ b/tests/CommunityToolkit.Aspire.KurrentDB.Tests/KurrentDBContainerFixture.cs
@@ -27,8 +27,7 @@ public sealed class KurrentDBContainerFixture : IAsyncLifetime
     {
         if (RequiresDockerAttribute.IsSupported)
         {
-            Container = new ContainerBuilder()
-              .WithImage($"{KurrentDBContainerImageTags.Registry}/{KurrentDBContainerImageTags.Image}:{KurrentDBContainerImageTags.Tag}")
+            Container = new ContainerBuilder($"{KurrentDBContainerImageTags.Registry}/{KurrentDBContainerImageTags.Image}:{KurrentDBContainerImageTags.Tag}")
               .WithPortBinding(2113, true)
               .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(2113)))
               .WithEnvironment("KURRENTDB_CLUSTER_SIZE", "1")

--- a/tests/CommunityToolkit.Aspire.Meilisearch.Tests/MeilisearchContainerFixture.cs
+++ b/tests/CommunityToolkit.Aspire.Meilisearch.Tests/MeilisearchContainerFixture.cs
@@ -45,8 +45,7 @@ public sealed class MeilisearchContainerFixture : IAsyncLifetime
             //The master key must be at least 16-bytes-long and composed of valid UTF-8 characters.
             _masterKey = param.GetDefaultValue();
 
-            Container = new ContainerBuilder()
-              .WithImage($"{MeilisearchContainerImageTags.Registry}/{MeilisearchContainerImageTags.Image}:{MeilisearchContainerImageTags.Tag}")
+            Container = new ContainerBuilder($"{MeilisearchContainerImageTags.Registry}/{MeilisearchContainerImageTags.Image}:{MeilisearchContainerImageTags.Tag}")
               .WithPortBinding(7700, true)
               .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(7700)))
               .WithEnvironment("MEILI_MASTER_KEY", _masterKey)

--- a/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/OllamaContainerFeature.cs
+++ b/tests/CommunityToolkit.Aspire.OllamaSharp.Tests/OllamaContainerFeature.cs
@@ -23,8 +23,7 @@ public class OllamaContainerFeature : IAsyncLifetime
     {
         if (RequiresDockerAttribute.IsSupported)
         {
-            Container = new ContainerBuilder()
-              .WithImage($"{OllamaContainerImageTags.Registry}/{OllamaContainerImageTags.Image}:{OllamaContainerImageTags.Tag}")
+            Container = new ContainerBuilder($"{OllamaContainerImageTags.Registry}/{OllamaContainerImageTags.Image}:{OllamaContainerImageTags.Tag}")
               .WithPortBinding(11434, true)
               .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(11434)))
               .Build();

--- a/tests/CommunityToolkit.Aspire.SurrealDb.Tests/SurrealDbContainerFixture.cs
+++ b/tests/CommunityToolkit.Aspire.SurrealDb.Tests/SurrealDbContainerFixture.cs
@@ -48,8 +48,7 @@ public sealed class SurrealDbContainerFixture : IAsyncLifetime
 
             _password = paramGenerator.GetDefaultValue();
 
-            Container = new ContainerBuilder()
-                .WithImage($"{SurrealDbContainerImageTags.Registry}/{SurrealDbContainerImageTags.Image}:{SurrealDbContainerImageTags.Tag}")
+            Container = new ContainerBuilder($"{SurrealDbContainerImageTags.Registry}/{SurrealDbContainerImageTags.Image}:{SurrealDbContainerImageTags.Tag}")
                 .WithPortBinding(_port, true)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(_port).ForPath("/health")))
                 .WithEnvironment("SURREAL_USER", _username)


### PR DESCRIPTION
`SSH.NET` has a CVE, and had to bump `TestContainers` too because it pulls in a different version of `SSH.NET`.