### PR TITLE
[K3s] Emit LF line endings in generated helm/kubectl scripts (fixes Windows-only busybox syntax error)

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.K3s/K3sBuilderExtensions.Helm.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.K3s/K3sBuilderExtensions.Helm.cs
@@ -224,22 +224,22 @@ public static class K3sHelmBuilderExtensions
         // can appear in the bind-mount before the k8s hostname resolves in the helm
         // container. Using `helm list` (which calls the k8s API) verifies both the
         // file and the network path before proceeding.
-        sb.AppendLine("_k3s_wait=0");
-        sb.AppendLine($"until [ -f {K3sFileHelpers.ContainerKubeconfigPath} ] && helm list --kubeconfig {K3sFileHelpers.ContainerKubeconfigPath} > /dev/null 2>&1; do");
-        sb.AppendLine("  _k3s_wait=$((_k3s_wait + 5))");
-        sb.AppendLine("  if [ \"$_k3s_wait\" -ge 600 ]; then");
-        sb.AppendLine("    echo 'Timed out waiting for k3s cluster to be ready after 10 minutes' >&2");
-        sb.AppendLine("    exit 1");
-        sb.AppendLine("  fi");
-        sb.AppendLine("  echo 'Waiting for k3s cluster to be ready and reachable...'");
-        sb.AppendLine("  sleep 5");
-        sb.AppendLine("done");
+        sb.AppendShellLine("_k3s_wait=0");
+        sb.AppendShellLine($"until [ -f {K3sFileHelpers.ContainerKubeconfigPath} ] && helm list --kubeconfig {K3sFileHelpers.ContainerKubeconfigPath} > /dev/null 2>&1; do");
+        sb.AppendShellLine("  _k3s_wait=$((_k3s_wait + 5))");
+        sb.AppendShellLine("  if [ \"$_k3s_wait\" -ge 600 ]; then");
+        sb.AppendShellLine("    echo 'Timed out waiting for k3s cluster to be ready after 10 minutes' >&2");
+        sb.AppendShellLine("    exit 1");
+        sb.AppendShellLine("  fi");
+        sb.AppendShellLine("  echo 'Waiting for k3s cluster to be ready and reachable...'");
+        sb.AppendShellLine("  sleep 5");
+        sb.AppendShellLine("done");
 
         if (release.RepoUrl is not null)
         {
             var alias = $"aspire-k3s-{release.ReleaseName}";
-            sb.AppendLine($"helm repo add --force-update {ShellEscape(alias)} {ShellEscape(release.RepoUrl)}");
-            sb.AppendLine($"helm repo update {ShellEscape(alias)}");
+            sb.AppendShellLine($"helm repo add --force-update {ShellEscape(alias)} {ShellEscape(release.RepoUrl)}");
+            sb.AppendShellLine($"helm repo update {ShellEscape(alias)}");
         }
 
         var chartRef = release.RepoUrl is not null

--- a/src/CommunityToolkit.Aspire.Hosting.K3s/K3sBuilderExtensions.Manifest.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.K3s/K3sBuilderExtensions.Manifest.cs
@@ -166,27 +166,27 @@ public static class K3sManifestBuilderExtensions
         // DCP sets up container network aliases asynchronously, so the kubeconfig file
         // can appear in the bind-mount before the k8s hostname resolves in the kubectl
         // container. Using `kubectl cluster-info` verifies both the file and the network.
-        sb.AppendLine("_k3s_wait=0");
-        sb.AppendLine($"until [ -f {K3sFileHelpers.ContainerKubeconfigPath} ] && kubectl cluster-info --kubeconfig {K3sFileHelpers.ContainerKubeconfigPath} > /dev/null 2>&1; do");
-        sb.AppendLine("  _k3s_wait=$((_k3s_wait + 5))");
-        sb.AppendLine("  if [ \"$_k3s_wait\" -ge 600 ]; then");
-        sb.AppendLine("    echo 'Timed out waiting for k3s cluster to be ready after 10 minutes' >&2");
-        sb.AppendLine("    exit 1");
-        sb.AppendLine("  fi");
-        sb.AppendLine("  echo 'Waiting for k3s cluster to be ready and reachable...'");
-        sb.AppendLine("  sleep 5");
-        sb.AppendLine("done");
+        sb.AppendShellLine("_k3s_wait=0");
+        sb.AppendShellLine($"until [ -f {K3sFileHelpers.ContainerKubeconfigPath} ] && kubectl cluster-info --kubeconfig {K3sFileHelpers.ContainerKubeconfigPath} > /dev/null 2>&1; do");
+        sb.AppendShellLine("  _k3s_wait=$((_k3s_wait + 5))");
+        sb.AppendShellLine("  if [ \"$_k3s_wait\" -ge 600 ]; then");
+        sb.AppendShellLine("    echo 'Timed out waiting for k3s cluster to be ready after 10 minutes' >&2");
+        sb.AppendShellLine("    exit 1");
+        sb.AppendShellLine("  fi");
+        sb.AppendShellLine("  echo 'Waiting for k3s cluster to be ready and reachable...'");
+        sb.AppendShellLine("  sleep 5");
+        sb.AppendShellLine("done");
 
         // Auto-detect kustomize: if a kustomization file is present, use -k.
         // Otherwise use -f with server-side apply.
         // Capture output so we can extract any CRD names that were applied.
-        sb.AppendLine("if [ -f /k8s-manifests/kustomization.yaml ] || [ -f /k8s-manifests/kustomization.yml ]; then");
-        sb.AppendLine("  echo 'Detected kustomization — using kubectl apply -k'");
-        sb.AppendLine("  APPLIED=$(kubectl apply -k /k8s-manifests --server-side --field-manager=aspire-k3s --force-conflicts)");
-        sb.AppendLine("else");
-        sb.AppendLine("  APPLIED=$(kubectl apply -f /k8s-manifests --server-side --field-manager=aspire-k3s --force-conflicts)");
-        sb.AppendLine("fi");
-        sb.AppendLine("echo \"$APPLIED\"");
+        sb.AppendShellLine("if [ -f /k8s-manifests/kustomization.yaml ] || [ -f /k8s-manifests/kustomization.yml ]; then");
+        sb.AppendShellLine("  echo 'Detected kustomization — using kubectl apply -k'");
+        sb.AppendShellLine("  APPLIED=$(kubectl apply -k /k8s-manifests --server-side --field-manager=aspire-k3s --force-conflicts)");
+        sb.AppendShellLine("else");
+        sb.AppendShellLine("  APPLIED=$(kubectl apply -f /k8s-manifests --server-side --field-manager=aspire-k3s --force-conflicts)");
+        sb.AppendShellLine("fi");
+        sb.AppendShellLine("echo \"$APPLIED\"");
 
         // Parse the apply output for CRD names — kubectl apply prints one line per resource
         // in the form "<kind>/<name> <verb>", e.g.:
@@ -194,11 +194,11 @@ public static class K3sManifestBuilderExtensions
         // Only lines starting with "customresourcedefinition." belong to this apply.
         // This avoids touching pre-existing or concurrently installed cluster CRDs and
         // prevents busybox xargs from returning exit code 123 when grep finds no match.
-        sb.AppendLine("CRD_NAMES=$(echo \"$APPLIED\" | grep '^customresourcedefinition\\.' | awk '{print $1}')");
-        sb.AppendLine("if [ -n \"$CRD_NAMES\" ]; then");
-        sb.AppendLine("  # shellcheck disable=SC2086");
-        sb.AppendLine("  kubectl wait --for=condition=Established $CRD_NAMES --timeout=300s");
-        sb.AppendLine("fi");
+        sb.AppendShellLine("CRD_NAMES=$(echo \"$APPLIED\" | grep '^customresourcedefinition\\.' | awk '{print $1}')");
+        sb.AppendShellLine("if [ -n \"$CRD_NAMES\" ]; then");
+        sb.AppendShellLine("  # shellcheck disable=SC2086");
+        sb.AppendShellLine("  kubectl wait --for=condition=Established $CRD_NAMES --timeout=300s");
+        sb.AppendShellLine("fi");
 
         return sb.ToString();
     }

--- a/src/CommunityToolkit.Aspire.Hosting.K3s/K3sShellScript.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.K3s/K3sShellScript.cs
@@ -1,0 +1,32 @@
+using System.Text;
+
+namespace CommunityToolkit.Aspire.Hosting;
+
+/// <summary>
+/// Helpers for composing the POSIX shell scripts that are generated on the host and
+/// injected into the Linux helper containers (<c>alpine/helm</c>, <c>alpine/kubectl</c>).
+/// </summary>
+internal static class K3sShellScript
+{
+    /// <summary>
+    /// Appends <paramref name="line"/> followed by a single LF (<c>\n</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Never use <see cref="StringBuilder.AppendLine(string)"/> for generated shell
+    /// scripts.</b> It appends <see cref="Environment.NewLine"/>, which is CRLF on Windows.
+    /// The scripts are executed by busybox <c>ash</c> inside a Linux container, and busybox
+    /// does not strip the trailing CR: a line such as <c>if [ ... ]; then</c> is tokenized
+    /// as <c>then\r</c>, which is not the <c>then</c> keyword. The <c>if</c> is therefore
+    /// never closed and the script aborts at EOF with
+    /// <c>syntax error: unexpected end of file (expecting "then")</c>.
+    /// </para>
+    /// <para>
+    /// The bug is invisible on Linux and macOS build agents (where
+    /// <see cref="Environment.NewLine"/> is already LF), so it only ever surfaces for
+    /// developers running the AppHost on Windows.
+    /// </para>
+    /// </remarks>
+    internal static StringBuilder AppendShellLine(this StringBuilder builder, string line) =>
+        builder.Append(line).Append('\n');
+}

--- a/tests/CommunityToolkit.Aspire.Hosting.K3s.Tests/HelmReleaseResourceTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.K3s.Tests/HelmReleaseResourceTests.cs
@@ -225,6 +225,20 @@ public class HelmReleaseResourceTests
     }
 
     [Fact]
+    public void BuildHelmScriptUsesLfLineEndingsOnly()
+    {
+        // Regression: StringBuilder.AppendLine emits Environment.NewLine (CRLF on Windows).
+        // busybox ash in alpine/helm does not strip the CR, so `then\r` is not the `then`
+        // keyword and the script dies with
+        // "syntax error: unexpected end of file (expecting \"then\")".
+        var script = K3sHelmBuilderExtensions.BuildHelmScript(
+            MakeRelease("argocd", "argo-cd", "https://argoproj.github.io/argo-helm", "7.8.0", "argocd",
+                new Dictionary<string, string> { ["server.service.type"] = "NodePort" }));
+
+        Assert.DoesNotContain('\r', script);
+    }
+
+    [Fact]
     public void BuildHelmScriptIncludesWaitAndNamespace()
     {
         var script = K3sHelmBuilderExtensions.BuildHelmScript(

--- a/tests/CommunityToolkit.Aspire.Hosting.K3s.Tests/K8sManifestResourceTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.K3s.Tests/K8sManifestResourceTests.cs
@@ -196,6 +196,18 @@ public class K8sManifestResourceTests
     }
 
     [Fact]
+    public void BuildManifestScriptUsesLfLineEndingsOnly()
+    {
+        // Regression: StringBuilder.AppendLine emits Environment.NewLine (CRLF on Windows).
+        // busybox ash in alpine/kubectl does not strip the CR, so `then\r` is not the
+        // `then` keyword and the script dies with
+        // "syntax error: unexpected end of file (expecting \"then\")".
+        var script = K3sManifestBuilderExtensions.BuildManifestScript();
+
+        Assert.DoesNotContain('\r', script);
+    }
+
+    [Fact]
     public void BuildManifestScriptAutoDetectsKustomize()
     {
         // The script checks for kustomization.yaml at runtime — no path argument needed.


### PR DESCRIPTION
**Closes #1550**

`BuildHelmScript` and `BuildManifestScript` compose their scripts with
`StringBuilder.AppendLine`, which appends `Environment.NewLine` — `\r\n` on Windows. The
scripts are injected into Linux containers and executed by busybox `ash`, which does not
strip the trailing CR, so `if [ ... ]; then` is tokenized as `then\r`. The `if` is never
closed and the script dies at EOF with
`syntax error: unexpected end of file (expecting "then")`.

This makes `AddHelmRelease` fail 100% of the time on Windows hosts, and `AddK8sManifest`
carries the identical defect — it just escapes notice because the helm release fails first
in the sample AppHost. Both are fixed here.

### Changes

- **New** `K3sShellScript.AppendShellLine` — appends a hard `\n`, with XML docs explaining
  the busybox failure it exists to prevent.
- `K3sBuilderExtensions.Helm.cs` — 12 call sites switched off `AppendLine`.
- `K3sBuilderExtensions.Manifest.cs` — 22 call sites switched off `AppendLine`.
- Regression tests asserting the generated scripts contain no `\r`:
  `BuildHelmScriptUsesLfLineEndingsOnly`, `BuildManifestScriptUsesLfLineEndingsOnly`.

I used a helper rather than normalizing the finished string with
`sb.ToString().Replace("\r\n", "\n")`, because the replace would also rewrite CRLF inside
caller-supplied data — a `WithHelmValue` value, a repo URL, a release name — on its way
into `helm --set`. The helper only controls terminators the generator itself emits and
leaves caller data byte-exact.

Not affected, for reviewers wondering why the cluster comes up healthy while the helm
container dies: `K3sInitEntrypointScript` is a C# raw string literal, and Roslyn
normalizes line endings inside those to `\n` regardless of the source file's endings.

## PR Checklist

- [x] Created a feature/dev branch in your fork (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Every new API (including internal ones) has full XML docs
- [x] Code follows all style conventions

## Other information

The new regression tests fail on Windows without the fix and are trivially green on Linux —
which is correct, the invariant is the same on every host. Since CI runs on Linux, they
guard the intent rather than reproduce the failure there.

Verified on Windows 11 ARM64 / Docker 29.7.2 by running the **actual generated scripts** in
the real images against a live `rancher/k3s:v1.36.0-k3s1` cluster:

| Script | Image | Result |
| --- | --- | --- |
| pre-fix bytes, reproduced exactly | `alpine/helm:3.18.0` | `syntax error: unexpected end of file (expecting "then")`, exit 2 |
| fixed helm script | `alpine/helm:3.18.0` | `STATUS: deployed`, exit 0 — `podinfo` pod Running |
| fixed manifest script, plain YAML | `alpine/kubectl:1.36.0` | `configmap/app-config serverside-applied`, exit 0 |
| fixed manifest script, kustomize | `alpine/kubectl:1.36.0` | `Detected kustomization`, `configmap/monitoring-config serverside-applied`, exit 0 |