### PR TITLE
chore(floci): bump floci-az container tag 0.10.0 → 0.11.0

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
@@ -8,7 +8,7 @@ internal static class FlociContainerImageTags
 
     public const string AzureRegistry = "docker.io";
     public const string AzureImage = "floci/floci-az";
-    public const string AzureTag = "0.10.0";
+    public const string AzureTag = "0.11.0";
 
     public const string GcpRegistry = "docker.io";
     public const string GcpImage = "floci/floci-gcp";


### PR DESCRIPTION
Fixes #1553

One-line bump of `FlociContainerImageTags.AzureTag` to the current floci-az release (0.11.0, 2026-08-18).

0.10.0 predates the fixes .NET SDK users need against `AddFlociAzure`:

- Service Bus `MSSBCBS` SASL negotiation (floci-io/floci-az#159) — `Azure.Messaging.ServiceBus` cannot connect to the 0.10.0 image at all
- Service Bus session support (floci-io/floci-az#123) and `CorrelationFilter` subscription rules (floci-io/floci-az#124)
- Cosmos container/item TTL (floci-io/floci-az#126) and composite-index enforcement (floci-io/floci-az#127)

Tests reference the constant symbolically, so no test changes. Builds clean.

The tag has no Renovate coverage — happy to add a release-tracking rule in a follow-up if wanted.

https://claude.ai/code/session_01K8waTF6dPtQNUmXz3i8xnG