### PR TITLE
chore(floci): bump AWS container tag 1.6.0 → 1.7.0

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
@@ -4,7 +4,7 @@ internal static class FlociContainerImageTags
 {
     public const string AwsRegistry = "docker.io";
     public const string AwsImage = "floci/floci";
-    public const string AwsTag = "1.6.0";
+    public const string AwsTag = "1.7.0";
 
     public const string AzureRegistry = "docker.io";
     public const string AzureImage = "floci/floci-az";


### PR DESCRIPTION
**Closes #1556**

Bumps the default floci/floci image from 1.6.0 to 1.7.0. This picks up the latest stable AWS emulator release, including Cognito refresh-token hardening, per-account DynamoDB and S3 isolation, correctness fixes, and expanded service coverage.

Release notes: https://github.com/floci-io/floci/releases/tag/1.7.0

## PR Checklist

- [x] Created a feature/dev branch in the fork
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits
- [x] Relevant tests pass
- [x] Contains no breaking changes
- [x] Code follows all style conventions

## Testing

dotnet test tests/CommunityToolkit.Aspire.Hosting.Floci.Tests/CommunityToolkit.Aspire.Hosting.Floci.Tests.csproj --configuration Release --no-restore --filter-class CommunityToolkit.Aspire.Hosting.Floci.Tests.AwsContainerResourceCreationTests

13 passed.