### PR TITLE
chore(floci): bump GCP container tag 0.6.0 → 0.7.0

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
@@ -12,7 +12,7 @@ internal static class FlociContainerImageTags
 
     public const string GcpRegistry = "docker.io";
     public const string GcpImage = "floci/floci-gcp";
-    public const string GcpTag = "0.6.0";
+    public const string GcpTag = "0.7.0";
 
     public const string UIRegistry = "docker.io";
     public const string UIImage = "floci/floci-ui";


### PR DESCRIPTION
**Closes #1557**

Bumps the default floci/floci-gcp image from 0.6.0 to 0.7.0. This picks up GCS precondition, CORS, metadata, and resumable-upload fixes, plus Firestore write-precondition and transaction-conflict enforcement.

Release notes: https://github.com/floci-io/floci-gcp/releases/tag/0.7.0

## PR Checklist

- [x] Created a feature/dev branch in the fork
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits
- [x] Relevant tests pass
- [x] Contains no breaking changes
- [x] Code follows all style conventions

## Testing

dotnet test tests/CommunityToolkit.Aspire.Hosting.Floci.Tests/CommunityToolkit.Aspire.Hosting.Floci.Tests.csproj --configuration Release --no-restore --filter-class CommunityToolkit.Aspire.Hosting.Floci.Tests.GcpContainerResourceCreationTests

10 passed.