### PR TITLE
chore(floci): bump UI container tag 0.2.0 → 0.3.0

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
@@ -16,5 +16,5 @@ internal static class FlociContainerImageTags
 
     public const string UIRegistry = "docker.io";
     public const string UIImage = "floci/floci-ui";
-    public const string UITag = "0.2.0";
+    public const string UITag = "0.3.0";
 }


### PR DESCRIPTION
**Closes #1558**

Bumps the default floci/floci-ui image from 0.2.0 to 0.3.0. This picks up new AWS, Azure, and GCP explorer support plus Docker and frontend fixes.

Release notes: https://github.com/floci-io/floci-ui/releases/tag/0.3.0

## PR Checklist

- [x] Created a feature/dev branch in the fork
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits
- [x] Relevant tests pass
- [x] Contains no breaking changes
- [x] Code follows all style conventions

## Testing

dotnet test tests/CommunityToolkit.Aspire.Hosting.Floci.Tests/CommunityToolkit.Aspire.Hosting.Floci.Tests.csproj --configuration Release --no-restore --filter-class *ContainerResourceCreationTests

33 passed.