### PR TITLE
chore(floci): bump AWS container tag 1.7.0 → 2.0.0

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
@@ -4,7 +4,7 @@ internal static class FlociContainerImageTags
 {
     public const string AwsRegistry = "docker.io";
     public const string AwsImage = "floci/floci";
-    public const string AwsTag = "1.7.0";
+    public const string AwsTag = "2.0.0";
 
     public const string AzureRegistry = "docker.io";
     public const string AzureImage = "floci/floci-az";


### PR DESCRIPTION
Bumps the default `floci/floci` image from `1.7.0` to `2.0.0`.

This release includes broad service correctness and coverage improvements. It also contains an upstream breaking change: Step Functions definitions now reject bare top-level JSONata references; callers must anchor them with `$states.input.<name>` or `$<name>`.

Release notes: https://github.com/floci-io/floci/releases/tag/2.0.0

## PR Checklist

- [x] Created a feature/dev branch in the fork
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits
- [x] Relevant tests pass
- [ ] Contains no breaking changes
- [x] Code follows all style conventions

## Testing

`dotnet vstest tests/CommunityToolkit.Aspire.Hosting.Floci.Tests/bin/Release/net10.0/CommunityToolkit.Aspire.Hosting.Floci.Tests.dll --TestCaseFilter:"FullyQualifiedName~AwsContainerResourceCreationTests"`

13 passed.