### PR TITLE
chore(floci): bump Azure container tag 0.11.0 → 0.12.0

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
@@ -8,7 +8,7 @@ internal static class FlociContainerImageTags
 
     public const string AzureRegistry = "docker.io";
     public const string AzureImage = "floci/floci-az";
-    public const string AzureTag = "0.11.0";
+    public const string AzureTag = "0.12.0";
 
     public const string GcpRegistry = "docker.io";
     public const string GcpImage = "floci/floci-gcp";


### PR DESCRIPTION
Bumps the default `floci/floci-az` image from `0.11.0` to `0.12.0`.

This release adds Azure Container Instances emulation, expands Service Bus behavior, and includes fixes across Blob Storage, Cosmos DB, Event Hubs, Functions, SQL, and Table Storage.

Release notes: https://github.com/floci-io/floci-az/releases/tag/0.12.0

## PR Checklist

- [x] Created a feature/dev branch in the fork
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits
- [x] Relevant tests pass
- [x] Contains no breaking changes
- [x] Code follows all style conventions

## Testing

`dotnet vstest tests/CommunityToolkit.Aspire.Hosting.Floci.Tests/bin/Release/net10.0/CommunityToolkit.Aspire.Hosting.Floci.Tests.dll --TestCaseFilter:"FullyQualifiedName~AzureContainerResourceCreationTests"`

10 passed.