### PR TITLE
chore(floci): bump GCP container tag 0.7.0 → 0.8.0

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
@@ -12,7 +12,7 @@ internal static class FlociContainerImageTags
 
     public const string GcpRegistry = "docker.io";
     public const string GcpImage = "floci/floci-gcp";
-    public const string GcpTag = "0.7.0";
+    public const string GcpTag = "0.8.0";
 
     public const string UIRegistry = "docker.io";
     public const string UIImage = "floci/floci-ui";


### PR DESCRIPTION
Bumps the default `floci/floci-gcp` image from `0.7.0` to `0.8.0`.

This release adds Cloud Storage gRPC v2, IAM policy support, atomic object moves, mixed HTTP/HTTPS serving, and Firestore and Cloud Storage fixes.

Release notes: https://github.com/floci-io/floci-gcp/releases/tag/0.8.0

## PR Checklist

- [x] Created a feature/dev branch in the fork
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits
- [x] Relevant tests pass
- [x] Contains no breaking changes
- [x] Code follows all style conventions

## Testing

`dotnet vstest tests/CommunityToolkit.Aspire.Hosting.Floci.Tests/bin/Release/net10.0/CommunityToolkit.Aspire.Hosting.Floci.Tests.dll --TestCaseFilter:"FullyQualifiedName~GcpContainerResourceCreationTests"`

10 passed.