### PR TITLE
chore(floci): bump UI container tag 0.3.0 → 0.4.0

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Floci/FlociContainerImageTags.cs
@@ -16,5 +16,5 @@ internal static class FlociContainerImageTags
 
     public const string UIRegistry = "docker.io";
     public const string UIImage = "floci/floci-ui";
-    public const string UITag = "0.3.0";
+    public const string UITag = "0.4.0";
 }


### PR DESCRIPTION
Bumps the default `floci/floci-ui` image from `0.3.0` to `0.4.0`.

This release expands Cloud Explorer with CloudFormation, EventBridge, IAM, Secrets Manager, Service Bus, SES, and other resource adapters, plus an EC2 launch-selector fix.

Release notes: https://github.com/floci-io/floci-ui/releases/tag/0.4.0

## PR Checklist

- [x] Created a feature/dev branch in the fork
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits
- [x] Relevant tests pass
- [x] Contains no breaking changes
- [x] Code follows all style conventions

## Testing

`dotnet vstest tests/CommunityToolkit.Aspire.Hosting.Floci.Tests/bin/Release/net10.0/CommunityToolkit.Aspire.Hosting.Floci.Tests.dll --TestCaseFilter:"FullyQualifiedName~ContainerResourceCreationTests"`

33 passed.