### PR TITLE
Enable polyglot package tagging for hosting integrations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="Aspire.Hosting.Keycloak" Version="$(AspireVersion)$(AspirePreviewSuffix)" />
     <PackageVersion Include="Aspire.Keycloak.Authentication" Version="$(AspireVersion)$(AspirePreviewSuffix)" />
     <PackageVersion Include="Aspire.Hosting.JavaScript" Version="$(AspireVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Integration.Analyzers" Version="$(AspireVersion)$(AspirePreviewSuffix)" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Python" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.Rabbitmq" Version="$(AspireVersion)" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
     <DebugType>embedded</DebugType>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <IsPreview>false</IsPreview>
+    <EnableAspireIntegrationAnalyzers Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('CommunityToolkit.Aspire.Hosting.'))">true</EnableAspireIntegrationAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +19,6 @@
     </PackageReference>
 
     <PackageReference Include="Microsoft.DotNet.GenAPI.Task" PrivateAssets="All" />
-    <PackageReference Include="Aspire.Hosting.Integration.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
     <DebugType>embedded</DebugType>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <IsPreview>false</IsPreview>
+    <!-- Aspire.Hosting supplies the integration analyzer through its build-transitive assets. -->
     <EnableAspireIntegrationAnalyzers Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('CommunityToolkit.Aspire.Hosting.'))">true</EnableAspireIntegrationAnalyzers>
   </PropertyGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -18,6 +18,9 @@
     <PackageReadmeFile>$(DocsPath)</PackageReadmeFile>
     <PackageOutputPath>../../nuget</PackageOutputPath>
     <PackageTags>aspire integration communitytoolkit dotnetcommunitytoolkit $(AdditionalPackageTags)</PackageTags>
+    <PackageTags Condition="'$(EnableAspireIntegrationAnalyzers)' == 'true'
+                            and '$(IsAspirePolyglotCompatible)' != 'false'
+                            and !$([System.String]::Concat(' ', '$(PackageTags)', ' ').Contains(' polyglot '))">$([System.String]::Concat('$(PackageTags)', ' polyglot').Trim())</PackageTags>
     
     <!-- If the project is packable, we generate its API surface in a separate file to be used by the API review process. -->
     <GenAPITargetPath Condition="'$(IsPackable)' == 'true'">$(MSBuildProjectDirectory)/api/$(AssemblyName).cs</GenAPITargetPath>


### PR DESCRIPTION
Fixes: #1573

Polyglot AppHosts only discover NuGet integrations marked with the `polyglot` tag. Community Toolkit hosting integrations already expose `[AspireExport]` APIs, but their packages do not currently advertise that compatibility.

This enables the bundled Aspire integration analyzer for `CommunityToolkit.Aspire.Hosting.*` projects and applies its opt-out contract to package metadata. Compatible projects receive `polyglot` unless they set `IsAspirePolyglotCompatible` to `false`; projects without export coverage fail with `ASPIREEXPORT017`. The redundant explicit analyzer package reference is removed because `Aspire.Hosting` supplies the analyzer when `EnableAspireIntegrationAnalyzers` is enabled.

## PR Checklist

- [x] Created a feature/dev branch in the repository (vs. submitting directly from a commit on main)
- [x] Based off latest main branch of toolkit
- [x] PR doesn't include merge commits (always rebase on top of our main, if needed)
- [ ] New integration (N/A)
  - [ ] Docs are written (N/A)
  - [ ] Added description of major feature to project description for NuGet package (N/A)
- [ ] Tests for the changes have been added (N/A: shared build metadata was validated by building and packing all source projects)
- [x] Contains **NO** breaking changes
- [ ] Every new API (including internal ones) has full XML docs (N/A: no APIs added)
- [x] Code follows all style conventions

## Other information

The full solution builds with .NET SDK 10.0.400 with zero `ASPIREEXPORT` diagnostics. A negative test using an unsupported `Encoding?` export parameter produced `ASPIREEXPORT004` for each target framework. All 78 source projects were packed and their `.nuspec` metadata inspected: 62 compatible packages contain `polyglot`, while the other 16 do not.

<details>
<summary>Packages that receive the polyglot tag (62)</summary>

- `CommunityToolkit.Aspire.Hosting.ActiveMQ`
- `CommunityToolkit.Aspire.Hosting.Adminer`
- `CommunityToolkit.Aspire.Hosting.Azure.Dapr`
- `CommunityToolkit.Aspire.Hosting.Azure.Dapr.Redis`
- `CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder`
- `CommunityToolkit.Aspire.Hosting.Azure.Extensions`
- `CommunityToolkit.Aspire.Hosting.Bitwarden.SecretManager`
- `CommunityToolkit.Aspire.Hosting.Bun`
- `CommunityToolkit.Aspire.Hosting.Dapr`
- `CommunityToolkit.Aspire.Hosting.DbGate`
- `CommunityToolkit.Aspire.Hosting.Dbx`
- `CommunityToolkit.Aspire.Hosting.Deno`
- `CommunityToolkit.Aspire.Hosting.DuckDB`
- `CommunityToolkit.Aspire.Hosting.Elasticsearch.Extensions`
- `CommunityToolkit.Aspire.Hosting.Flagd`
- `CommunityToolkit.Aspire.Hosting.Floci`
- `CommunityToolkit.Aspire.Hosting.Flyway`
- `CommunityToolkit.Aspire.Hosting.GoFeatureFlag`
- `CommunityToolkit.Aspire.Hosting.Golang`
- `CommunityToolkit.Aspire.Hosting.Java`
- `CommunityToolkit.Aspire.Hosting.JavaScript.Extensions`
- `CommunityToolkit.Aspire.Hosting.K3s`
- `CommunityToolkit.Aspire.Hosting.Keycloak.Extensions`
- `CommunityToolkit.Aspire.Hosting.Kind`
- `CommunityToolkit.Aspire.Hosting.KurrentDB`
- `CommunityToolkit.Aspire.Hosting.LavinMQ`
- `CommunityToolkit.Aspire.Hosting.Listmonk`
- `CommunityToolkit.Aspire.Hosting.Logto`
- `CommunityToolkit.Aspire.Hosting.MailPit`
- `CommunityToolkit.Aspire.Hosting.McpInspector`
- `CommunityToolkit.Aspire.Hosting.Meilisearch`
- `CommunityToolkit.Aspire.Hosting.Minio`
- `CommunityToolkit.Aspire.Hosting.MongoDB.Extensions`
- `CommunityToolkit.Aspire.Hosting.Mosquitto`
- `CommunityToolkit.Aspire.Hosting.MySql.Extensions`
- `CommunityToolkit.Aspire.Hosting.Ngrok`
- `CommunityToolkit.Aspire.Hosting.Ollama`
- `CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector`
- `CommunityToolkit.Aspire.Hosting.PapercutSmtp`
- `CommunityToolkit.Aspire.Hosting.Perl`
- `CommunityToolkit.Aspire.Hosting.Posta`
- `CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions`
- `CommunityToolkit.Aspire.Hosting.PowerShell`
- `CommunityToolkit.Aspire.Hosting.Python.Extensions`
- `CommunityToolkit.Aspire.Hosting.RavenDB`
- `CommunityToolkit.Aspire.Hosting.RedPanda`
- `CommunityToolkit.Aspire.Hosting.Redis.Extensions`
- `CommunityToolkit.Aspire.Hosting.Rust`
- `CommunityToolkit.Aspire.Hosting.RustFs`
- `CommunityToolkit.Aspire.Hosting.SeaweedFS`
- `CommunityToolkit.Aspire.Hosting.Sftp`
- `CommunityToolkit.Aspire.Hosting.Solr`
- `CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects`
- `CommunityToolkit.Aspire.Hosting.SqlServer.Extensions`
- `CommunityToolkit.Aspire.Hosting.Sqlite`
- `CommunityToolkit.Aspire.Hosting.Squad`
- `CommunityToolkit.Aspire.Hosting.StableDiffusionCpp`
- `CommunityToolkit.Aspire.Hosting.Stripe`
- `CommunityToolkit.Aspire.Hosting.SurrealDb`
- `CommunityToolkit.Aspire.Hosting.Umami`
- `CommunityToolkit.Aspire.Hosting.Zitadel`
- `CommunityToolkit.Aspire.Hosting.k6`

</details>

<details>
<summary>Packages that do not receive the polyglot tag (16)</summary>

- `CommunityToolkit.Aspire.Bitwarden.SecretManager`
- `CommunityToolkit.Aspire.DuckDB.NET.Data`
- `CommunityToolkit.Aspire.GoFeatureFlag`
- `CommunityToolkit.Aspire.KurrentDB`
- `CommunityToolkit.Aspire.Logto.Client`
- `CommunityToolkit.Aspire.MassTransit.RabbitMQ`
- `CommunityToolkit.Aspire.Meilisearch`
- `CommunityToolkit.Aspire.Microsoft.Data.Sqlite`
- `CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite`
- `CommunityToolkit.Aspire.Minio.Client`
- `CommunityToolkit.Aspire.OllamaSharp`
- `CommunityToolkit.Aspire.Posta`
- `CommunityToolkit.Aspire.RavenDB.Client`
- `CommunityToolkit.Aspire.SeaweedFS.Client`
- `CommunityToolkit.Aspire.Sftp`
- `CommunityToolkit.Aspire.SurrealDb`

</details>