### PR TITLE
Update Posta to 0.15.0 and expose template languages

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Posta/PostaContainerImageTags.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Posta/PostaContainerImageTags.cs
@@ -8,6 +8,6 @@ internal static class PostaContainerImageTags
     /// <remarks>jkaninda/posta</remarks>
     public const string Image = "jkaninda/posta";
 
-    /// <remarks>0.13.1</remarks>
-    public const string Tag = "0.13.1";
+    /// <remarks>0.15.0</remarks>
+    public const string Tag = "0.15.0";
 }

--- a/src/CommunityToolkit.Aspire.Posta/Models/Shared/ListTemplatesResponseDataItem.cs
+++ b/src/CommunityToolkit.Aspire.Posta/Models/Shared/ListTemplatesResponseDataItem.cs
@@ -33,6 +33,10 @@ public class ListTemplatesResponseDataItem
     [JsonPropertyName("id")]
     public int? Id { get; set; }
 
+    /// <summary>Gets or sets the languages available in the active template version.</summary>
+    [JsonPropertyName("languages")]
+    public IReadOnlyList<string>? Languages { get; set; }
+
     /// <summary>Gets or sets <c>last_edited_by</c>.</summary>
     [JsonPropertyName("last_edited_by")]
     public ListTemplatesResponseDataItemLastEditedBy? LastEditedBy { get; set; }

--- a/tests/CommunityToolkit.Aspire.Hosting.Posta.Tests/ContainerResourceCreationTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Posta.Tests/ContainerResourceCreationTests.cs
@@ -155,7 +155,7 @@ public class ContainerResourceCreationTests
 
         Assert.Equal("posta", resource.Name);
         Assert.True(resource.TryGetLastAnnotation(out ContainerImageAnnotation? imageAnnotations));
-        Assert.Equal("0.13.1", imageAnnotations.Tag);
+        Assert.Equal("0.15.0", imageAnnotations.Tag);
         Assert.Equal(PostaContainerImageTags.Tag, imageAnnotations.Tag);
         Assert.NotEqual("latest", imageAnnotations.Tag);
         Assert.Equal(PostaContainerImageTags.Image, imageAnnotations.Image);


### PR DESCRIPTION
Updates the Posta container image from 0.13.1 to 0.15.0 and exposes the `languages` array returned by the template list API through `ListTemplatesResponseDataItem.Languages`. The nullable property preserves compatibility with responses from older servers.

The hosting resource test now asserts the 0.15.0 tag. This is a follow-up to #1461; the existing integration is already in main.

## PR Checklist

- [x] Created a feature branch in a fork
- [x] Based on the latest upstream main at preparation time
- [x] No merge commits
- [x] Existing container image assertion updated
- [x] Contains no breaking API changes
- [x] New property has XML documentation

## Validation

- Posta client tests: 10 passed.
- Posta hosting tests: 22 passed, including container startup and health endpoint verification.
- `git diff --check HEAD~1 HEAD` passed.
