### PR TITLE
Remove explicit Source Link package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,7 +60,6 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(ServiceDiscoveryVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(DotNetExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(DotNetExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(DotNetExtensionsVersion)" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
     <!-- OpenTelemetry packages -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,6 @@
     <IsPackable>true</IsPackable>
 
     <DocsPath>README.md</DocsPath>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <IsPreview>false</IsPreview>
@@ -14,11 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-
     <PackageReference Include="Microsoft.DotNet.GenAPI.Task" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
## Why

Microsoft.SourceLink.GitHub 8.0.0 transitively restores Microsoft.Build.Tasks.Git 8.0.0, which is affected by GHSA-23fw-v26w-5fgq. The .NET SDK has included and enabled Source Link providers for GitHub-hosted SDK-style projects since .NET 8, so this explicit package reference is redundant and overrides the SDK-provided implementation.

Removing the reference lets projects use the SDK-provided Source Link implementation and removes the vulnerable NuGet dependency from restore.

Fixes failures in #1583, #1584 + more

## Changes

- remove the redundant Microsoft.SourceLink.GitHub package reference and central version
- remove the now-default EmbedUntrackedSources property
- retain the existing shared PublishRepositoryUrl setting

## Validation

Ran:

`	ext
dotnet pack src/CommunityToolkit.Aspire.Hosting.Adminer/CommunityToolkit.Aspire.Hosting.Adminer.csproj --configuration Release --output <temp>
` 

The package built successfully for 
et8.0, 
et9.0, and 
et10.0. Inspected the resulting .nupkg and confirmed its nuspec still contains the Git repository URL, branch, and commit. Also confirmed the built 
et10.0 assembly contains the GitHub Source Link mapping.