### PR TITLE
Fix Zitadel generated password complexity requirements

### DIFF
--- a/src/CommunityToolkit.Aspire.Hosting.Zitadel/ZitadelHostingExtensions.cs
+++ b/src/CommunityToolkit.Aspire.Hosting.Zitadel/ZitadelHostingExtensions.cs
@@ -35,7 +35,7 @@ public static class ZitadelHostingExtensions
         ArgumentNullException.ThrowIfNull(name);
 
         var usernameParameter = username?.Resource ?? new ParameterResource($"{name}-username", _ => "admin", false);
-        var passwordParameter = password?.Resource ?? ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, $"{name}-password", minSpecial: 1);
+        var passwordParameter = password?.Resource ?? ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, $"{name}-password", minLower: 1, minUpper: 1, minNumeric: 1, minSpecial: 1);
         var masterKeyParameter = masterKey?.Resource ?? ParameterResourceBuilderExtensions.CreateGeneratedParameter(builder, $"{name}-masterKey", true, new GenerateParameterDefault
         {
             MinLength = 32, // Zitadel requires 32, CreateDefaultPasswordParameter generates 22

--- a/tests/CommunityToolkit.Aspire.Hosting.Zitadel.Tests/ZitadelHostingExtensionsTests.cs
+++ b/tests/CommunityToolkit.Aspire.Hosting.Zitadel.Tests/ZitadelHostingExtensionsTests.cs
@@ -71,6 +71,28 @@ public class ZitadelHostingExtensionsTests
     }
 
     [Fact]
+    public void AddZitadel_Default_Password_Meets_Complexity_Requirements()
+    {
+        // Publish mode exposes the generator without wrapping it in persisted user secrets.
+        var builder = DistributedApplication.CreateBuilder(["Publishing:Publisher=manifest"]);
+        var zitadel = builder.AddZitadel("zitadel");
+
+        // Check the guarantees so this test cannot pass by chance if a minimum is removed.
+        var generation = Assert.IsType<GenerateParameterDefault>(zitadel.Resource.AdminPasswordParameter.Default);
+        Assert.True(generation.MinLower >= 1);
+        Assert.True(generation.MinUpper >= 1);
+        Assert.True(generation.MinNumeric >= 1);
+        Assert.True(generation.MinSpecial >= 1);
+
+        var password = generation.GetDefaultValue();
+
+        Assert.Contains(password, char.IsLower);
+        Assert.Contains(password, char.IsUpper);
+        Assert.Contains(password, char.IsDigit);
+        Assert.Contains(password, c => !char.IsLetterOrDigit(c));
+    }
+
+    [Fact]
     public void AddZitadel_Uses_Custom_Username_And_Password()
     {
         var builder = DistributedApplication.CreateBuilder();


### PR DESCRIPTION
Zitadel can fail during initial setup when its generated admin password contains no digits. Require at least one lowercase letter, uppercase letter, digit, and special character when generating the default password.

Aspire defaults `minLower`, `minUpper`, and `minNumeric` to zero; enabling those character classes does not guarantee their presence. The integration previously specified only `minSpecial: 1`.

## Failure evidence

The [failed GitHub Actions job in run 34691146787](https://github.com/CommunityToolkit/Aspire/actions/runs/34691146787/job/103546584127?pr=1588), observed on #1588, reported 7 failed tests out of 31. Zitadel v4.15.0 logged:

```text
2026-09-12T11:31:14.927Z level=ERROR msg="migration failed" ... name=03_default_instance ... err.message=Errors.User.PasswordComplexityPolicy.HasNumber
2026-09-12T11:31:14.929Z level=ERROR+6 msg="setup failed, skipping cleanup" ... err.message=Errors.User.PasswordComplexityPolicy.HasNumber
```

The tests then failed with:

```text
Aspire.Hosting.DistributedApplicationException : Stopped waiting for resource 'zitadel' to become healthy because it failed to start.
```

The log excerpts above omit unrelated fields with `...`. The existing database dependency already calls `.WaitFor(database)`, and the failing tests already wait for Zitadel to become healthy. The setup failure requires a password-generation fix.

## Validation

- Passed all 15 `ZitadelHostingExtensionsTests` (including the new password regression test) with `dotnet run --project tests/CommunityToolkit.Aspire.Hosting.Zitadel.Tests --configuration Release -- --filter-class '*ZitadelHostingExtensionsTests'`.
- Attempted the seven affected C# integration tests; local fixture startup is blocked because the Docker daemon is unavailable (`Container runtime 'docker' was found but appears to be unhealthy`). Container validation remains for CI.
- `git diff --check` passed.

## PR Checklist

- [x] Created a feature branch in a fork
- [x] Based off latest main branch of toolkit at creation
- [x] PR does not include merge commits
- [x] Contains no breaking API changes
- [x] Code follows existing style conventions



The regression test inspects all four generation minima and validates a freshly generated password. It fails against the original minSpecial-only settings and passes with the fix. Publish mode exposes the generator directly without persisted user secrets.

